### PR TITLE
feat: add flush and safeFlush for flushing queues

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,13 +13,16 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1
 
       - name: Lint
         run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
 
       - name: Typecheck
         run: npm run typecheck
@@ -32,7 +35,7 @@ jobs:
 
       - name: Pack dry run
         run: npm pack --dry-run --ignore-scripts
-      
+
       - name: Size Limit
         uses: andresz1/size-limit-action@v1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Pack dry run
-        run: npm pack --dry-run --ignore-scripts
+      - name: Pack contents
+        run: npm run test:pack
 
       - name: Size Limit
         uses: andresz1/size-limit-action@v1

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -1,8 +1,8 @@
 name: Test and 🚀 Release
 on:
-    push:
-      branches:
-        - main
+  push:
+    branches:
+      - main
 jobs:
   build:
     name: Build, lint, and test on Node
@@ -23,13 +23,16 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1
 
       - name: Lint
         run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
 
       - name: Typecheck
         run: npm run typecheck
@@ -45,6 +48,6 @@ jobs:
 
       - name: 🚀 Release
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            npm run release
+          npm run release

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Pack dry run
-        run: npm pack --dry-run --ignore-scripts
+      - name: Pack contents
+        run: npm run test:pack
 
       - name: 🚀 Release
         env:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+dist-ssr
+coverage
+package-lock.json
+*.log
+*.local
+.env
+.env.*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ const buttonQueueClick = () => {
   });
 };
 
-const buttonSignalClickWithOptions = () => {
-  signal(
+const buttonSignalClickWithOptions = async () => {
+  await signal(
     "example_signal_event_name_with_options",
     {
       custom_data: "other_data", // any custom data as required
@@ -72,8 +72,8 @@ const buttonSignalClickWithOptions = () => {
   ); // telemetryDeck options (optional)
 };
 
-const buttonQueueClickWithOptions = () => {
-  queue(
+const buttonQueueClickWithOptions = async () => {
+  await queue(
     "example_queue_event_name_with_options",
     {
       custom_data: "other_data", // any custom data as required

--- a/README.md
+++ b/README.md
@@ -123,11 +123,15 @@ const buttonQueueClickWithOptions = async () => {
 ```ts
 import { useTelemetryDeck } from "@peerigon/telemetrydeck-vue";
 
-const { flush, safeFlush } = useTelemetryDeck();
+const { queue, flush, safeFlush, getQueueCount } = useTelemetryDeck();
 
+await queue("example_queue_event_name");
+console.log(getQueueCount());
 await flush();
 await safeFlush();
 ```
+
+`getQueueCount()` returns the number of signals currently stored in the SDK queue. It does not indicate whether queued signals have been sent successfully.
 
 `signal()`, `queue()`, and `flush()` return promises and may reject (for example on network failures).  
 Use `safeSignal()`, `safeQueue()`, and `safeFlush()` for fire-and-forget analytics calls to avoid unhandled promise rejections.

--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ npm i @peerigon/telemetrydeck-vue --save
 Set up the plugin in your application setup:
 
 ```javascript
-import { createApp } from 'vue';
-import TelemetryDeckPlugin from '@peerigon/telemetrydeck-vue';
+import TelemetryDeckPlugin from "@peerigon/telemetrydeck-vue";
+import { createApp } from "vue";
 
 const app = createApp(App);
 app.use(TelemetryDeckPlugin, {
   appID: "{your telemetrydeck appID}",
   testMode: true, // optional - defaults to false
-  clientUser: 'guest', // optional - defaults to 'guest'
+  clientUser: "guest", // optional - defaults to 'guest'
   onError: (error, meta) => {
-    console.debug('TelemetryDeck failed', meta, error);
+    console.debug("TelemetryDeck failed", meta, error);
   }, // optional
 });
 
-app.mount('#app');
+app.mount("#app");
 ```
 
 ## Basic Usage
@@ -38,55 +38,81 @@ app.mount('#app');
 ```vue
 <script setup lang="ts">
 import { useTelemetryDeck } from "@peerigon/telemetrydeck-vue";
-const { signal, queue, safeSignal, safeQueue, setClientUser } = useTelemetryDeck();
+
+const { signal, queue, safeSignal, safeQueue, setClientUser } =
+  useTelemetryDeck();
 
 const changeClientUserClick = () => {
-  setClientUser('user' + Math.floor(Math.random() * 1000));
+  setClientUser("user" + Math.floor(Math.random() * 1000));
 };
 
 const buttonSignalClick = () => {
-  safeSignal('example_signal_event_name', {
-    custom_data: 'other_data', // any custom data as required
+  safeSignal("example_signal_event_name", {
+    custom_data: "other_data", // any custom data as required
   });
 };
 
 const buttonQueueClick = () => {
-  safeQueue('example_queue_event_name', {
-    custom_data: 'other_data', // any custom data as required
+  safeQueue("example_queue_event_name", {
+    custom_data: "other_data", // any custom data as required
   });
 };
 
 const buttonSignalClickWithOptions = () => {
-  signal('example_signal_event_name_with_options', {
-    custom_data: 'other_data', // any custom data as required
-  }, {
-    testMode: true,
-    clientUser: 'other_user',
-    appID: 'other_app_id',
-  }); // telemetryDeck options (optional)
+  signal(
+    "example_signal_event_name_with_options",
+    {
+      custom_data: "other_data", // any custom data as required
+    },
+    {
+      testMode: true,
+      clientUser: "other_user",
+      appID: "other_app_id",
+    },
+  ); // telemetryDeck options (optional)
 };
 
 const buttonQueueClickWithOptions = () => {
-  queue('example_queue_event_name_with_options', {
-    custom_data: 'other_data', // any custom data as required
-  }, {
-    testMode: true,
-    clientUser: 'other_user',
-    appID: 'other_app_id',
-  }); // telemetryDeck options (optional)
+  queue(
+    "example_queue_event_name_with_options",
+    {
+      custom_data: "other_data", // any custom data as required
+    },
+    {
+      testMode: true,
+      clientUser: "other_user",
+      appID: "other_app_id",
+    },
+  ); // telemetryDeck options (optional)
 };
 </script>
 
 <template>
   <div>
     <div>
-      <button id="btnSignalClick" @click="buttonSignalClick">Log a click with signal</button>
-      <button id="btnQueueClick" @click="buttonQueueClick">Log a click with queue</button>
-      <button id="btnSetClient" @click="changeClientUserClick">Change user</button>
+      <button id="btnSignalClick" @click="buttonSignalClick">
+        Log a click with signal
+      </button>
+      <button id="btnQueueClick" @click="buttonQueueClick">
+        Log a click with queue
+      </button>
+      <button id="btnSetClient" @click="changeClientUserClick">
+        Change user
+      </button>
     </div>
     <div>
-      <button id="btnSignalClickWithOptions" @click="buttonSignalClickWithOptions">Log a click with signal with Options</button>
-      <button id="btnQueueClickWithOptions" @click="buttonQueueClickWithOptions">Log a click with queue with Options</button>
+      <button
+        id="btnSignalClickWithOptions"
+        @click="buttonSignalClickWithOptions"
+      >
+        Log a click with signal with Options
+      </button>
+      <button
+        id="btnQueueClickWithOptions"
+        @click="buttonQueueClickWithOptions"
+      >
+        Log a click with queue with Options
+      </button>
     </div>
   </div>
 </template>
@@ -124,4 +150,18 @@ Run the tests with:
 
 ```shell
 npm run test
+```
+
+### Formatting
+
+Format the project with:
+
+```shell
+npm run format
+```
+
+Check formatting without writing changes with:
+
+```shell
+npm run format:check
 ```

--- a/README.md
+++ b/README.md
@@ -92,8 +92,19 @@ const buttonQueueClickWithOptions = () => {
 </template>
 ```
 
-`signal()` and `queue()` return promises and may reject (for example on network failures).  
-Use `safeSignal()` and `safeQueue()` for fire-and-forget analytics calls to avoid unhandled promise rejections.
+## Flushing Queued Events
+
+```ts
+import { useTelemetryDeck } from "@peerigon/telemetrydeck-vue";
+
+const { flush, safeFlush } = useTelemetryDeck();
+
+await flush();
+await safeFlush();
+```
+
+`signal()`, `queue()`, and `flush()` return promises and may reject (for example on network failures).  
+Use `safeSignal()`, `safeQueue()`, and `safeFlush()` for fire-and-forget analytics calls to avoid unhandled promise rejections.
 
 ## Contributions
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,16 @@
-import globals from "globals";
 import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
-
+import globals from "globals";
+import tseslint from "typescript-eslint";
 
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts,vue}"]},
-  {languageOptions: { globals: globals.browser }},
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
+  { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   ...pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
+  {
+    files: ["**/*.vue"],
+    languageOptions: { parserOptions: { parser: tseslint.parser } },
+  },
 ];

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Vue + TS</title>
+    <title>TelemetryDeck Vue Demo</title>
   </head>
   <body>
     <div id="app"></div>

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,6 @@
+import { plugin } from "./src/plugin";
+
 export * from "./src/hooks";
 export type { TelemetryDeckPluginOptions } from "./src/plugin";
-import { plugin } from "./src/plugin";
+
 export default plugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-plugin-vue": "^10.9.2",
         "globals": "^17.6.0",
         "jsdom": "^29.1.1",
+        "prettier": "^3.8.4",
         "rollup": "^4.18.1",
         "rollup-plugin-delete": "^3.0.2",
         "rollup-plugin-peer-deps-external": "^2.2.4",
@@ -13584,7 +13585,6 @@
       "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "size": "size-limit",
     "test": "vitest --coverage",
     "test:exports": "node tests/exports/import.mjs && node tests/exports/require.cjs",
+    "test:pack": "node tests/pack/contents.mjs",
     "typecheck": "vue-tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.build.json"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@peerigon/telemetrydeck-vue",
-  "private": false,
   "version": "0.0.0-semantically-released",
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/peerigon/telemetrydeck-vue.git"
+  },
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -14,38 +15,30 @@
       "default": "./dist/index.mjs"
     }
   },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/types/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
-    "dev": "vite",
-    "size": "size-limit",
     "build": "rollup -c",
     "postbuild": "npm run test:exports",
+    "dev": "vite",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint src",
     "prepack": "npm run build",
+    "preview": "vite preview",
+    "release": "semantic-release",
+    "size": "size-limit",
     "test": "vitest --coverage",
     "test:exports": "node tests/exports/import.mjs && node tests/exports/require.cjs",
-    "typecheck": "vue-tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.build.json",
-    "lint": "eslint src",
-    "preview": "vite preview",
-    "release": "semantic-release"
+    "typecheck": "vue-tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.build.json"
   },
-  "size-limit": [
-    {
-      "path": "dist/index.mjs",
-      "limit": "10 kB"
-    },
-    {
-      "path": "dist/index.cjs",
-      "limit": "10 kB"
-    }
-  ],
   "dependencies": {
     "@telemetrydeck/sdk": "^2.0.4"
-  },
-  "peerDependencies": {
-    "vue": "^3.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/peerigon/telemetrydeck-vue.git"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
@@ -65,6 +58,7 @@
     "eslint-plugin-vue": "^10.9.2",
     "globals": "^17.6.0",
     "jsdom": "^29.1.1",
+    "prettier": "^3.8.4",
     "rollup": "^4.18.1",
     "rollup-plugin-delete": "^3.0.2",
     "rollup-plugin-peer-deps-external": "^2.2.4",
@@ -79,12 +73,21 @@
     "vue-eslint-parser": "^10.4.1",
     "vue-tsc": "^3.3.5"
   },
+  "peerDependencies": {
+    "vue": "^3.0.0"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true
   },
-  "files": [
-    "dist",
-    "README.md"
+  "size-limit": [
+    {
+      "path": "dist/index.mjs",
+      "limit": "10 kB"
+    },
+    {
+      "path": "dist/index.cjs",
+      "limit": "10 kB"
+    }
   ]
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,1 @@
+export { default } from "@peerigon/configs/prettier";

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,38 +1,38 @@
-import typescript from 'rollup-plugin-typescript2';
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import terser from '@rollup/plugin-terser';
-import del from 'rollup-plugin-delete';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
+import commonjs from "@rollup/plugin-commonjs";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import terser from "@rollup/plugin-terser";
+import del from "rollup-plugin-delete";
+import peerDepsExternal from "rollup-plugin-peer-deps-external";
+import typescript from "rollup-plugin-typescript2";
 
 export default [
   {
-    input: 'index.ts',
-    external: ['@telemetrydeck/sdk'],
+    input: "index.ts",
+    external: ["@telemetrydeck/sdk"],
     output: [
       {
-        format: 'esm',
-        file: 'dist/index.mjs',
-        exports: 'named',
-        plugins: [terser()]
+        format: "esm",
+        file: "dist/index.mjs",
+        exports: "named",
+        plugins: [terser()],
       },
       {
-        format: 'cjs',
-        file: 'dist/index.cjs',
-        exports: 'named',
-        plugins: [terser()]
-      }
+        format: "cjs",
+        file: "dist/index.cjs",
+        exports: "named",
+        plugins: [terser()],
+      },
     ],
     plugins: [
-      del({ targets: 'dist/*' }),
+      del({ targets: "dist/*" }),
       peerDepsExternal(),
       typescript({
-        tsconfig: 'tsconfig.build.json',
+        tsconfig: "tsconfig.build.json",
         check: false,
-        useTsconfigDeclarationDir: true
+        useTsconfigDeclarationDir: true,
       }),
       nodeResolve(),
-      commonjs()
-    ]
-  }
+      commonjs(),
+    ],
+  },
 ];

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,7 @@ const {
   signal,
   queue,
   flush,
+  getQueueCount,
   safeSignal,
   safeQueue,
   safeFlush,
@@ -22,7 +23,7 @@ const {
 } = useTelemetryDeck();
 
 const currentClientUser = ref("guest");
-const queuedEvents = ref(0);
+const queuedEvents = ref(getQueueCount());
 const lastAction = ref("");
 const lastResult = ref("");
 const lastError = ref("");
@@ -42,7 +43,7 @@ const options = {
 const changeClientUserClick = () => {
   currentClientUser.value = `user${Math.floor(Math.random() * 1000)}`;
   setClientUser(currentClientUser.value);
-  lastAction.value = `Client user changed to ${currentClientUser.value}`;
+  lastAction.value = "Change user";
   lastResult.value = "setClientUser completed";
 };
 
@@ -52,14 +53,18 @@ const clearStatusClick = () => {
   lastError.value = "";
 };
 
+const refreshQueuedEvents = () => {
+  queuedEvents.value = getQueueCount();
+};
+
 const buttonSignalClick = async () => {
-  await runRawAction("signal", "Signal sent immediately", () =>
+  await runRawAction("signal", "Send signal", () =>
     signal("example_signal_event_name", payload("signal")),
   );
 };
 
 const buttonSignalClickWithOptions = async () => {
-  await runRawAction("signal", "Signal sent with per-call options", () =>
+  await runRawAction("signal", "Send signal with options", () =>
     signal(
       "example_signal_event_name_with_options",
       payload("signal_with_options"),
@@ -69,59 +74,50 @@ const buttonSignalClickWithOptions = async () => {
 };
 
 const buttonQueueClick = async () => {
-  await runRawAction(
-    "queue",
-    "Event added to the queue",
-    () => queue("example_queue_event_name", payload("queue")),
-    () => {
-      queuedEvents.value += 1;
-    },
+  await runRawAction("queue", "Queue event", () =>
+    queue("example_queue_event_name", payload("queue")),
   );
+  refreshQueuedEvents();
 };
 
 const buttonQueueClickWithOptions = async () => {
-  await runRawAction(
-    "queue",
-    "Event with options added to the queue",
-    () =>
-      queue(
-        "example_queue_event_name_with_options",
-        payload("queue_with_options"),
-        options,
-      ),
-    () => {
-      queuedEvents.value += 1;
-    },
+  await runRawAction("queue", "Queue event with options", () =>
+    queue(
+      "example_queue_event_name_with_options",
+      payload("queue_with_options"),
+      options,
+    ),
   );
+  refreshQueuedEvents();
 };
 
 const buttonFlushClick = async () => {
-  await runRawAction("flush", "Queued events flushed", flush, () => {
-    queuedEvents.value = 0;
-  });
+  await runRawAction("flush", "Flush queue", flush);
+  refreshQueuedEvents();
 };
 
 const buttonSafeSignalClick = async () => {
-  await runSafeAction("safeSignal", "Safe signal completed", () =>
+  await runSafeAction("safeSignal", "Safe signal", () =>
     safeSignal("example_safe_signal_event_name", payload("safe_signal")),
   );
 };
 
 const buttonSafeQueueClick = async () => {
-  await runSafeAction("safeQueue", "Safe queue completed", () =>
+  await runSafeAction("safeQueue", "Safe queue", () =>
     safeQueue("example_safe_queue_event_name", payload("safe_queue")),
   );
+  refreshQueuedEvents();
 };
 
 const buttonSafeFlushClick = async () => {
-  await runSafeAction("safeFlush", "Safe flush completed", safeFlush);
+  await runSafeAction("safeFlush", "Safe flush", safeFlush);
+  refreshQueuedEvents();
 };
 
 const runRawAction = async (
   method: TelemetryDeckMethod,
   actionLabel: string,
   action: () => Promise<unknown>,
-  onResolved?: () => void,
 ) => {
   lastAction.value = actionLabel;
   lastResult.value = "";
@@ -129,7 +125,6 @@ const runRawAction = async (
 
   try {
     const response = await action();
-    onResolved?.();
     lastResult.value = formatResolvedResult(method, response);
   } catch (error) {
     lastResult.value = `${method} rejected`;

--- a/src/App.vue
+++ b/src/App.vue
@@ -40,10 +40,13 @@ const options = {
   appID: "other_app_id",
 };
 
-const changeClientUserClick = () => {
-  currentClientUser.value = `user${Math.floor(Math.random() * 1000)}`;
-  setClientUser(currentClientUser.value);
+const changeClientUserClick = async () => {
   lastAction.value = "Change user";
+  lastResult.value = "";
+  lastError.value = "";
+
+  currentClientUser.value = `user${Math.floor(Math.random() * 1000)}`;
+  await setClientUser(currentClientUser.value);
   lastResult.value = "setClientUser completed";
 };
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -124,6 +124,8 @@ const runRawAction = async (
   onResolved?: () => void,
 ) => {
   lastAction.value = actionLabel;
+  lastResult.value = "";
+  lastError.value = "";
 
   try {
     const response = await action();
@@ -139,12 +141,18 @@ const runSafeAction = async (
   method: string,
   actionLabel: string,
   action: () => Promise<void>,
-  onResolved?: () => void,
 ) => {
-  await action();
-  onResolved?.();
   lastAction.value = actionLabel;
-  lastResult.value = `${method} promise resolved`;
+  lastResult.value = "";
+  lastError.value = "";
+
+  try {
+    await action();
+    lastResult.value = `${method} promise resolved`;
+  } catch (error) {
+    lastResult.value = `${method} rejected`;
+    lastError.value = `${method} failed: ${getErrorMessage(error)}`;
+  }
 };
 
 const getErrorMessage = (error: unknown) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,75 +1,453 @@
 <script setup lang="ts">
-  import { useTelemetryDeck } from "../index.ts";
-  const { signal, queue, setClientUser } = useTelemetryDeck();
+import { onMounted, onUnmounted, ref } from "vue";
 
-  const changeClientUserClick = () => {
-    setClientUser('user' + Math.floor(Math.random() * 1000));
-  };
+import { useTelemetryDeck } from "../index.ts";
+import type { TelemetryDeckErrorMeta } from "../index.ts";
 
-  const buttonSignalClick = () => {
-    signal('example_signal_event_name', {
-      custom_data: 'other_data',
-      timestamp: new Date().toISOString(),
-    });
-  };
-  const buttonQueueClick = () => {
-    queue('example_queue_event_name', {
-      custom_data: 'other_data',
-      timestamp: new Date().toISOString(),
-    });
-  };
-  const buttonSignalClickWithOptions = () => {
-    signal('example_signal_event_name_with_options', {
-      custom_data: 'other_data',
-      timestamp: new Date().toISOString(),
-    }, {
-      testMode: true,
-      clientUser: 'other_user',
-      appID: 'other_app_id',
-    }
-  );
-  };
-  const buttonQueueClickWithOptions = () => {
-    queue('example_queue_event_name_with_options', {
-      custom_data: 'other_data',
-      timestamp: new Date().toISOString(),
-    },
-    {
-      testMode: true,
-      clientUser: 'other_user',
-      appID: 'other_app_id',
-    });
-  };
+interface TelemetryDeckErrorEventDetail {
+  message: string;
+  meta: TelemetryDeckErrorMeta;
+}
+
+const { signal, queue, flush, safeSignal, safeQueue, safeFlush, setClientUser } =
+  useTelemetryDeck();
+
+const currentClientUser = ref("guest");
+const queuedEvents = ref(0);
+const lastAction = ref("");
+const lastResult = ref("");
+const lastError = ref("");
+
+const payload = (source: string) => ({
+  source,
+  custom_data: "other_data",
+  timestamp: new Date().toISOString(),
+});
+
+const options = {
+  testMode: true,
+  clientUser: "other_user",
+  appID: "other_app_id",
+};
+
+const changeClientUserClick = () => {
+  currentClientUser.value = `user${Math.floor(Math.random() * 1000)}`;
+  setClientUser(currentClientUser.value);
+  lastAction.value = `Client user changed to ${currentClientUser.value}`;
+  lastResult.value = "setClientUser completed";
+};
+
+const clearStatusClick = () => {
+  lastAction.value = "";
+  lastResult.value = "";
+  lastError.value = "";
+};
+
+const buttonSignalClick = async () => {
+  lastAction.value = "Signal sent immediately";
+  try {
+    const response = await signal("example_signal_event_name", payload("signal"));
+    lastResult.value = formatResolvedResult("signal", response);
+  } catch (error) {
+    lastResult.value = "signal rejected";
+    lastError.value = `signal failed: ${getErrorMessage(error)}`;
+  }
+};
+
+const buttonSignalClickWithOptions = async () => {
+  lastAction.value = "Signal sent with per-call options";
+  try {
+    const response = await signal(
+      "example_signal_event_name_with_options",
+      payload("signal_with_options"),
+      options,
+    );
+    lastResult.value = formatResolvedResult("signal", response);
+  } catch (error) {
+    lastResult.value = "signal rejected";
+    lastError.value = `signal failed: ${getErrorMessage(error)}`;
+  }
+};
+
+const buttonQueueClick = async () => {
+  lastAction.value = "Event added to the queue";
+  try {
+    const response = await queue("example_queue_event_name", payload("queue"));
+    queuedEvents.value += 1;
+    lastResult.value = formatResolvedResult("queue", response);
+  } catch (error) {
+    lastResult.value = "queue rejected";
+    lastError.value = `queue failed: ${getErrorMessage(error)}`;
+  }
+};
+
+const buttonQueueClickWithOptions = async () => {
+  lastAction.value = "Event with options added to the queue";
+  try {
+    const response = await queue(
+      "example_queue_event_name_with_options",
+      payload("queue_with_options"),
+      options,
+    );
+    queuedEvents.value += 1;
+    lastResult.value = formatResolvedResult("queue", response);
+  } catch (error) {
+    lastResult.value = "queue rejected";
+    lastError.value = `queue failed: ${getErrorMessage(error)}`;
+  }
+};
+
+const buttonFlushClick = async () => {
+  lastAction.value = "Queued events flushed";
+  try {
+    const response = await flush();
+    queuedEvents.value = 0;
+    lastResult.value = formatResolvedResult("flush", response);
+  } catch (error) {
+    lastResult.value = "flush rejected";
+    lastError.value = `flush failed: ${getErrorMessage(error)}`;
+  }
+};
+
+const buttonSafeSignalClick = async () => {
+  await safeSignal("example_safe_signal_event_name", payload("safe_signal"));
+  lastAction.value = "Safe signal completed";
+  lastResult.value = "safeSignal promise resolved";
+};
+
+const buttonSafeQueueClick = async () => {
+  await safeQueue("example_safe_queue_event_name", payload("safe_queue"));
+  queuedEvents.value += 1;
+  lastAction.value = "Safe queue completed";
+  lastResult.value = "safeQueue promise resolved";
+};
+
+const buttonSafeFlushClick = async () => {
+  await safeFlush();
+  queuedEvents.value = 0;
+  lastAction.value = "Safe flush completed";
+  lastResult.value = "safeFlush promise resolved";
+};
+
+const getErrorMessage = (error: unknown) => {
+  return error instanceof Error ? error.message : String(error);
+};
+
+const formatResolvedResult = (method: string, response: unknown) => {
+  if (response === undefined) {
+    return `${method} promise resolved without response`;
+  }
+
+  if (typeof response === "string") {
+    return `${method} response: ${response}`;
+  }
+
+  return `${method} response: ${JSON.stringify(response)}`;
+};
+
+const formatErrorMeta = (meta: TelemetryDeckErrorMeta) => {
+  return meta.type ? `${meta.method}: ${meta.type}` : meta.method;
+};
+
+const handleTelemetryDeckError = (event: Event) => {
+  const { message, meta } = (event as CustomEvent<TelemetryDeckErrorEventDetail>).detail;
+  lastError.value = `${formatErrorMeta(meta)} failed: ${message}`;
+};
+
+onMounted(() => {
+  window.addEventListener("telemetrydeck:error", handleTelemetryDeckError);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("telemetrydeck:error", handleTelemetryDeckError);
+});
 </script>
+
 <template>
-  <div>
-    <a href="https://vitejs.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
-    </a>
-    <div>
-    <button id="btnSignalClick" @click="buttonSignalClick">Log a click with signal</button>
-    <button id="btnQueueClick" @click="buttonQueueClick">Log a click with queue</button>
-    <button id="btnSetClient" @click="changeClientUserClick">Change user</button>
-    </div>
-    <div>
-      <button id="btnSignalClickWithOptions" @click="buttonSignalClickWithOptions">Log a click with signal with Options</button>
-      <button id="btnQueueClickWithOptions" @click="buttonQueueClickWithOptions">Log a click with queue with Options</button>
-    </div>
-  </div>
-  
+  <main class="demo-shell">
+    <header class="demo-header">
+      <div>
+        <p class="eyebrow">TelemetryDeck Vue</p>
+        <h1>Demo controls</h1>
+      </div>
+      <dl class="status-list" aria-label="TelemetryDeck demo state">
+        <div>
+          <dt>User</dt>
+          <dd>{{ currentClientUser }}</dd>
+        </div>
+        <div>
+          <dt>Queued</dt>
+          <dd>{{ queuedEvents }}</dd>
+        </div>
+        <div class="status-wide">
+          <dt>Last action</dt>
+          <dd id="lastTelemetryAction">{{ lastAction }}</dd>
+        </div>
+        <div class="status-wide">
+          <dt>Last result</dt>
+          <dd id="lastTelemetryResult">{{ lastResult }}</dd>
+        </div>
+        <div class="status-wide status-error">
+          <dt>Last error</dt>
+          <dd id="lastTelemetryError">{{ lastError }}</dd>
+        </div>
+      </dl>
+      <button id="btnClearStatus" class="clear-action" type="button" @click="clearStatusClick">
+        Clear last action
+      </button>
+    </header>
+
+    <section class="demo-section" aria-labelledby="send-now-title">
+      <div>
+        <p class="section-kicker">Send now</p>
+        <h2 id="send-now-title">Signal</h2>
+      </div>
+      <div class="button-grid">
+        <button id="btnSignalClick" class="primary-action" type="button" @click="buttonSignalClick">
+          Send signal
+        </button>
+        <button
+          id="btnSignalClickWithOptions"
+          class="secondary-action"
+          type="button"
+          @click="buttonSignalClickWithOptions"
+        >
+          Send signal with options
+        </button>
+      </div>
+    </section>
+
+    <section class="demo-section" aria-labelledby="queue-title">
+      <div>
+        <p class="section-kicker">Queue for later</p>
+        <h2 id="queue-title">Queue and flush</h2>
+      </div>
+      <div class="button-grid">
+        <button id="btnQueueClick" class="queue-action" type="button" @click="buttonQueueClick">
+          Queue event
+        </button>
+        <button
+          id="btnQueueClickWithOptions"
+          class="queue-action"
+          type="button"
+          @click="buttonQueueClickWithOptions"
+        >
+          Queue event with options
+        </button>
+        <button id="btnFlushClick" class="flush-action" type="button" @click="buttonFlushClick">
+          Flush queue
+        </button>
+      </div>
+    </section>
+
+    <section class="demo-section" aria-labelledby="safe-title">
+      <div>
+        <p class="section-kicker">Fire and forget</p>
+        <h2 id="safe-title">Safe wrappers</h2>
+      </div>
+      <div class="button-grid">
+        <button id="btnSafeSignalClick" class="safe-action" type="button" @click="buttonSafeSignalClick">
+          Safe signal
+        </button>
+        <button id="btnSafeQueueClick" class="safe-action" type="button" @click="buttonSafeQueueClick">
+          Safe queue
+        </button>
+        <button id="btnSafeFlushClick" class="safe-action" type="button" @click="buttonSafeFlushClick">
+          Safe flush
+        </button>
+      </div>
+    </section>
+
+    <section class="demo-section user-section" aria-labelledby="user-title">
+      <div>
+        <p class="section-kicker">User state</p>
+        <h2 id="user-title">Client user</h2>
+      </div>
+      <button id="btnSetClient" class="user-action" type="button" @click="changeClientUserClick">
+        Change user
+      </button>
+    </section>
+  </main>
 </template>
 
 <style scoped>
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+.demo-shell {
+  width: min(100%, 1040px);
+  margin: 0 auto;
+  padding: 48px 24px;
 }
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+
+.demo-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 460px);
+  gap: 32px;
+  align-items: end;
+  padding-bottom: 32px;
+  border-bottom: 1px solid #d8dee8;
 }
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #42b883aa);
+
+.eyebrow,
+.section-kicker {
+  margin: 0 0 8px;
+  color: #4a6a58;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  color: #162033;
+}
+
+h1 {
+  font-size: 2.75rem;
+  line-height: 1;
+}
+
+h2 {
+  font-size: 1.35rem;
+}
+
+.status-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.status-list div {
+  min-width: 0;
+  padding: 14px 16px;
+  border: 1px solid #d8dee8;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.status-wide {
+  grid-column: 1 / -1;
+}
+
+.status-error dd {
+  color: #8a1f14;
+}
+
+.clear-action {
+  grid-column: 2;
+  justify-self: end;
+  width: auto;
+  min-height: 40px;
+  padding: 8px 14px;
+  background: #ffffff;
+  color: #3e4f68;
+  border-color: #c4ccd8;
+  font-weight: 800;
+}
+
+dt {
+  color: #637087;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+dd {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+  color: #162033;
+  font-weight: 700;
+}
+
+.demo-section {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+  padding: 28px 0;
+  border-bottom: 1px solid #d8dee8;
+}
+
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+button {
+  min-height: 56px;
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 12px 16px;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    border-color 160ms ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgb(22 32 51 / 14%);
+}
+
+button:focus-visible {
+  outline: 3px solid #f2c94c;
+  outline-offset: 3px;
+}
+
+.primary-action {
+  background: #2157d6;
+}
+
+.secondary-action {
+  background: #2b6b78;
+}
+
+.queue-action {
+  background: #74652f;
+}
+
+.flush-action {
+  background: #c23a2b;
+}
+
+.safe-action {
+  background: #2e7448;
+}
+
+.user-action {
+  max-width: 220px;
+  background: #3e4f68;
+}
+
+@media (max-width: 760px) {
+  .demo-shell {
+    padding: 32px 16px;
+  }
+
+  .demo-header,
+  .demo-section {
+    grid-template-columns: 1fr;
+  }
+
+  .clear-action {
+    grid-column: auto;
+    justify-self: stretch;
+    width: 100%;
+  }
+
+  h1 {
+    font-size: 2.2rem;
+  }
+
+  .user-action {
+    max-width: none;
+  }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,16 +1,25 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from "vue";
-
-import { useTelemetryDeck } from "../index.ts";
-import type { TelemetryDeckErrorMeta, TelemetryDeckMethod } from "../index.ts";
+import {
+  useTelemetryDeck,
+  type TelemetryDeckErrorMeta,
+  type TelemetryDeckMethod,
+} from "../index.ts";
 
 interface TelemetryDeckErrorEventDetail {
   message: string;
   meta: TelemetryDeckErrorMeta;
 }
 
-const { signal, queue, flush, safeSignal, safeQueue, safeFlush, setClientUser } =
-  useTelemetryDeck();
+const {
+  signal,
+  queue,
+  flush,
+  safeSignal,
+  safeQueue,
+  safeFlush,
+  setClientUser,
+} = useTelemetryDeck();
 
 const currentClientUser = ref("guest");
 const queuedEvents = ref(0);
@@ -74,11 +83,12 @@ const buttonQueueClickWithOptions = async () => {
   await runRawAction(
     "queue",
     "Event with options added to the queue",
-    () => queue(
-      "example_queue_event_name_with_options",
-      payload("queue_with_options"),
-      options,
-    ),
+    () =>
+      queue(
+        "example_queue_event_name_with_options",
+        payload("queue_with_options"),
+        options,
+      ),
     () => {
       queuedEvents.value += 1;
     },
@@ -86,14 +96,9 @@ const buttonQueueClickWithOptions = async () => {
 };
 
 const buttonFlushClick = async () => {
-  await runRawAction(
-    "flush",
-    "Queued events flushed",
-    flush,
-    () => {
-      queuedEvents.value = 0;
-    },
-  );
+  await runRawAction("flush", "Queued events flushed", flush, () => {
+    queuedEvents.value = 0;
+  });
 };
 
 const buttonSafeSignalClick = async () => {
@@ -103,19 +108,13 @@ const buttonSafeSignalClick = async () => {
 };
 
 const buttonSafeQueueClick = async () => {
-  await runSafeAction(
-    "safeQueue",
-    "Safe queue completed",
-    () => safeQueue("example_safe_queue_event_name", payload("safe_queue")),
+  await runSafeAction("safeQueue", "Safe queue completed", () =>
+    safeQueue("example_safe_queue_event_name", payload("safe_queue")),
   );
 };
 
 const buttonSafeFlushClick = async () => {
-  await runSafeAction(
-    "safeFlush",
-    "Safe flush completed",
-    safeFlush,
-  );
+  await runSafeAction("safeFlush", "Safe flush completed", safeFlush);
 };
 
 const runRawAction = async (
@@ -152,7 +151,10 @@ const getErrorMessage = (error: unknown) => {
   return error instanceof Error ? error.message : String(error);
 };
 
-const formatResolvedResult = (method: TelemetryDeckMethod, response: unknown) => {
+const formatResolvedResult = (
+  method: TelemetryDeckMethod,
+  response: unknown,
+) => {
   if (response === undefined) {
     return `${method} promise resolved without response`;
   }
@@ -173,7 +175,9 @@ const formatErrorMeta = (meta: TelemetryDeckErrorMeta) => {
 };
 
 const handleTelemetryDeckError = (event: Event) => {
-  const { message, meta } = (event as CustomEvent<TelemetryDeckErrorEventDetail>).detail;
+  const { message, meta } = (
+    event as CustomEvent<TelemetryDeckErrorEventDetail>
+  ).detail;
   lastError.value = `${formatErrorMeta(meta)} failed: ${message}`;
 };
 
@@ -215,7 +219,12 @@ onUnmounted(() => {
           <dd id="lastTelemetryError">{{ lastError }}</dd>
         </div>
       </dl>
-      <button id="btnClearStatus" class="clear-action" type="button" @click="clearStatusClick">
+      <button
+        id="btnClearStatus"
+        class="clear-action"
+        type="button"
+        @click="clearStatusClick"
+      >
         Clear last action
       </button>
     </header>
@@ -226,7 +235,12 @@ onUnmounted(() => {
         <h2 id="send-now-title">Signal</h2>
       </div>
       <div class="button-grid">
-        <button id="btnSignalClick" class="primary-action" type="button" @click="buttonSignalClick">
+        <button
+          id="btnSignalClick"
+          class="primary-action"
+          type="button"
+          @click="buttonSignalClick"
+        >
           Send signal
         </button>
         <button
@@ -246,7 +260,12 @@ onUnmounted(() => {
         <h2 id="queue-title">Queue and flush</h2>
       </div>
       <div class="button-grid">
-        <button id="btnQueueClick" class="queue-action" type="button" @click="buttonQueueClick">
+        <button
+          id="btnQueueClick"
+          class="queue-action"
+          type="button"
+          @click="buttonQueueClick"
+        >
           Queue event
         </button>
         <button
@@ -257,7 +276,12 @@ onUnmounted(() => {
         >
           Queue event with options
         </button>
-        <button id="btnFlushClick" class="flush-action" type="button" @click="buttonFlushClick">
+        <button
+          id="btnFlushClick"
+          class="flush-action"
+          type="button"
+          @click="buttonFlushClick"
+        >
           Flush queue
         </button>
       </div>
@@ -269,13 +293,28 @@ onUnmounted(() => {
         <h2 id="safe-title">Safe wrappers</h2>
       </div>
       <div class="button-grid">
-        <button id="btnSafeSignalClick" class="safe-action" type="button" @click="buttonSafeSignalClick">
+        <button
+          id="btnSafeSignalClick"
+          class="safe-action"
+          type="button"
+          @click="buttonSafeSignalClick"
+        >
           Safe signal
         </button>
-        <button id="btnSafeQueueClick" class="safe-action" type="button" @click="buttonSafeQueueClick">
+        <button
+          id="btnSafeQueueClick"
+          class="safe-action"
+          type="button"
+          @click="buttonSafeQueueClick"
+        >
           Safe queue
         </button>
-        <button id="btnSafeFlushClick" class="safe-action" type="button" @click="buttonSafeFlushClick">
+        <button
+          id="btnSafeFlushClick"
+          class="safe-action"
+          type="button"
+          @click="buttonSafeFlushClick"
+        >
           Safe flush
         </button>
       </div>
@@ -286,7 +325,12 @@ onUnmounted(() => {
         <p class="section-kicker">User state</p>
         <h2 id="user-title">Client user</h2>
       </div>
-      <button id="btnSetClient" class="user-action" type="button" @click="changeClientUserClick">
+      <button
+        id="btnSetClient"
+        class="user-action"
+        type="button"
+        @click="changeClientUserClick"
+      >
         Change user
       </button>
     </section>
@@ -303,9 +347,9 @@ onUnmounted(() => {
 .demo-header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(320px, 460px);
-  gap: 32px;
   align-items: end;
   padding-bottom: 32px;
+  gap: 32px;
   border-bottom: 1px solid #d8dee8;
 }
 
@@ -313,8 +357,8 @@ onUnmounted(() => {
 .section-kicker {
   margin: 0 0 8px;
   color: #4a6a58;
-  font-size: 0.78rem;
   font-weight: 700;
+  font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -337,8 +381,8 @@ h2 {
 .status-list {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
   margin: 0;
+  gap: 12px;
 }
 
 .status-list div {
@@ -363,32 +407,32 @@ h2 {
   width: auto;
   min-height: 40px;
   padding: 8px 14px;
+  border-color: #c4ccd8;
   background: #ffffff;
   color: #3e4f68;
-  border-color: #c4ccd8;
   font-weight: 800;
 }
 
 dt {
   color: #637087;
-  font-size: 0.78rem;
   font-weight: 700;
+  font-size: 0.78rem;
   text-transform: uppercase;
 }
 
 dd {
   margin: 4px 0 0;
-  overflow-wrap: anywhere;
   color: #162033;
   font-weight: 700;
+  overflow-wrap: anywhere;
 }
 
 .demo-section {
   display: grid;
   grid-template-columns: 220px minmax(0, 1fr);
-  gap: 24px;
   align-items: start;
   padding: 28px 0;
+  gap: 24px;
   border-bottom: 1px solid #d8dee8;
 }
 
@@ -399,11 +443,11 @@ dd {
 }
 
 button {
-  min-height: 56px;
   width: 100%;
+  min-height: 56px;
+  padding: 12px 16px;
   border: 1px solid transparent;
   border-radius: 8px;
-  padding: 12px 16px;
   color: #ffffff;
   font: inherit;
   font-weight: 800;

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 import { onMounted, onUnmounted, ref } from "vue";
 
 import { useTelemetryDeck } from "../index.ts";
-import type { TelemetryDeckErrorMeta } from "../index.ts";
+import type { TelemetryDeckErrorMeta, TelemetryDeckMethod } from "../index.ts";
 
 interface TelemetryDeckErrorEventDetail {
   message: string;
@@ -44,96 +44,115 @@ const clearStatusClick = () => {
 };
 
 const buttonSignalClick = async () => {
-  lastAction.value = "Signal sent immediately";
-  try {
-    const response = await signal("example_signal_event_name", payload("signal"));
-    lastResult.value = formatResolvedResult("signal", response);
-  } catch (error) {
-    lastResult.value = "signal rejected";
-    lastError.value = `signal failed: ${getErrorMessage(error)}`;
-  }
+  await runRawAction("signal", "Signal sent immediately", () =>
+    signal("example_signal_event_name", payload("signal")),
+  );
 };
 
 const buttonSignalClickWithOptions = async () => {
-  lastAction.value = "Signal sent with per-call options";
-  try {
-    const response = await signal(
+  await runRawAction("signal", "Signal sent with per-call options", () =>
+    signal(
       "example_signal_event_name_with_options",
       payload("signal_with_options"),
       options,
-    );
-    lastResult.value = formatResolvedResult("signal", response);
-  } catch (error) {
-    lastResult.value = "signal rejected";
-    lastError.value = `signal failed: ${getErrorMessage(error)}`;
-  }
+    ),
+  );
 };
 
 const buttonQueueClick = async () => {
-  lastAction.value = "Event added to the queue";
-  try {
-    const response = await queue("example_queue_event_name", payload("queue"));
-    queuedEvents.value += 1;
-    lastResult.value = formatResolvedResult("queue", response);
-  } catch (error) {
-    lastResult.value = "queue rejected";
-    lastError.value = `queue failed: ${getErrorMessage(error)}`;
-  }
+  await runRawAction(
+    "queue",
+    "Event added to the queue",
+    () => queue("example_queue_event_name", payload("queue")),
+    () => {
+      queuedEvents.value += 1;
+    },
+  );
 };
 
 const buttonQueueClickWithOptions = async () => {
-  lastAction.value = "Event with options added to the queue";
-  try {
-    const response = await queue(
+  await runRawAction(
+    "queue",
+    "Event with options added to the queue",
+    () => queue(
       "example_queue_event_name_with_options",
       payload("queue_with_options"),
       options,
-    );
-    queuedEvents.value += 1;
-    lastResult.value = formatResolvedResult("queue", response);
-  } catch (error) {
-    lastResult.value = "queue rejected";
-    lastError.value = `queue failed: ${getErrorMessage(error)}`;
-  }
+    ),
+    () => {
+      queuedEvents.value += 1;
+    },
+  );
 };
 
 const buttonFlushClick = async () => {
-  lastAction.value = "Queued events flushed";
-  try {
-    const response = await flush();
-    queuedEvents.value = 0;
-    lastResult.value = formatResolvedResult("flush", response);
-  } catch (error) {
-    lastResult.value = "flush rejected";
-    lastError.value = `flush failed: ${getErrorMessage(error)}`;
-  }
+  await runRawAction(
+    "flush",
+    "Queued events flushed",
+    flush,
+    () => {
+      queuedEvents.value = 0;
+    },
+  );
 };
 
 const buttonSafeSignalClick = async () => {
-  await safeSignal("example_safe_signal_event_name", payload("safe_signal"));
-  lastAction.value = "Safe signal completed";
-  lastResult.value = "safeSignal promise resolved";
+  await runSafeAction("safeSignal", "Safe signal completed", () =>
+    safeSignal("example_safe_signal_event_name", payload("safe_signal")),
+  );
 };
 
 const buttonSafeQueueClick = async () => {
-  await safeQueue("example_safe_queue_event_name", payload("safe_queue"));
-  queuedEvents.value += 1;
-  lastAction.value = "Safe queue completed";
-  lastResult.value = "safeQueue promise resolved";
+  await runSafeAction(
+    "safeQueue",
+    "Safe queue completed",
+    () => safeQueue("example_safe_queue_event_name", payload("safe_queue")),
+  );
 };
 
 const buttonSafeFlushClick = async () => {
-  await safeFlush();
-  queuedEvents.value = 0;
-  lastAction.value = "Safe flush completed";
-  lastResult.value = "safeFlush promise resolved";
+  await runSafeAction(
+    "safeFlush",
+    "Safe flush completed",
+    safeFlush,
+  );
+};
+
+const runRawAction = async (
+  method: TelemetryDeckMethod,
+  actionLabel: string,
+  action: () => Promise<unknown>,
+  onResolved?: () => void,
+) => {
+  lastAction.value = actionLabel;
+
+  try {
+    const response = await action();
+    onResolved?.();
+    lastResult.value = formatResolvedResult(method, response);
+  } catch (error) {
+    lastResult.value = `${method} rejected`;
+    lastError.value = `${method} failed: ${getErrorMessage(error)}`;
+  }
+};
+
+const runSafeAction = async (
+  method: string,
+  actionLabel: string,
+  action: () => Promise<void>,
+  onResolved?: () => void,
+) => {
+  await action();
+  onResolved?.();
+  lastAction.value = actionLabel;
+  lastResult.value = `${method} promise resolved`;
 };
 
 const getErrorMessage = (error: unknown) => {
   return error instanceof Error ? error.message : String(error);
 };
 
-const formatResolvedResult = (method: string, response: unknown) => {
+const formatResolvedResult = (method: TelemetryDeckMethod, response: unknown) => {
   if (response === undefined) {
     return `${method} promise resolved without response`;
   }
@@ -142,7 +161,11 @@ const formatResolvedResult = (method: string, response: unknown) => {
     return `${method} response: ${response}`;
   }
 
-  return `${method} response: ${JSON.stringify(response)}`;
+  try {
+    return `${method} response: ${JSON.stringify(response)}`;
+  } catch {
+    return `${method} response could not be serialized`;
+  }
 };
 
 const formatErrorMeta = (meta: TelemetryDeckErrorMeta) => {
@@ -177,7 +200,7 @@ onUnmounted(() => {
         </div>
         <div>
           <dt>Queued</dt>
-          <dd>{{ queuedEvents }}</dd>
+          <dd id="queuedTelemetryEvents">{{ queuedEvents }}</dd>
         </div>
         <div class="status-wide">
           <dt>Last action</dt>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -86,7 +86,7 @@ export function useTelemetryDeck() {
 
   const safeFlush = async () => {
     try {
-      await td?.flush();
+      await flush();
     } catch (error) {
       await handleError(error, { method: "flush" });
     }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,7 +2,7 @@ import { inject } from 'vue';
 import type TelemetryDeck from '@telemetrydeck/sdk';
 import type { TelemetryDeckOptions, TelemetryDeckPayload } from '@telemetrydeck/sdk';
 
-export type TelemetryDeckMethod = 'signal' | 'queue';
+export type TelemetryDeckMethod = 'signal' | 'queue' | 'flush';
 
 export interface TelemetryDeckErrorMeta {
   method: TelemetryDeckMethod;
@@ -42,6 +42,10 @@ export function useTelemetryDeck() {
     return td?.queue(type, payload, options);
   };
 
+  const flush = async () => {
+    return td?.flush();
+  };
+
   const safeSignal = async (type: string, payload?: TelemetryDeckPayload, options?: TelemetryDeckOptions) => {
     try {
       await td?.signal(type, payload, options);
@@ -58,11 +62,21 @@ export function useTelemetryDeck() {
     }
   };
 
+  const safeFlush = async () => {
+    try {
+      await td?.flush();
+    } catch (error) {
+      await handleError(error, { method: 'flush' });
+    }
+  };
+
   return {
     setClientUser,
     signal,
     queue,
+    flush,
     safeSignal,
     safeQueue,
+    safeFlush,
   };
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -60,6 +60,10 @@ export function useTelemetryDeck() {
     return td?.flush();
   };
 
+  const getQueueCount = () => {
+    return td?.store?.values().length ?? 0;
+  };
+
   const safeSignal = async (
     type: string,
     payload?: TelemetryDeckPayload,
@@ -97,6 +101,7 @@ export function useTelemetryDeck() {
     signal,
     queue,
     flush,
+    getQueueCount,
     safeSignal,
     safeQueue,
     safeFlush,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -66,7 +66,7 @@ export function useTelemetryDeck() {
     options?: TelemetryDeckOptions,
   ) => {
     try {
-      await td?.signal(type, payload, options);
+      await signal(type, payload, options);
     } catch (error) {
       await handleError(error, { method: "signal", type, payload, options });
     }
@@ -78,7 +78,7 @@ export function useTelemetryDeck() {
     options?: TelemetryDeckOptions,
   ) => {
     try {
-      await td?.queue(type, payload, options);
+      await queue(type, payload, options);
     } catch (error) {
       await handleError(error, { method: "queue", type, payload, options });
     }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,8 +1,11 @@
-import { inject } from 'vue';
-import type TelemetryDeck from '@telemetrydeck/sdk';
-import type { TelemetryDeckOptions, TelemetryDeckPayload } from '@telemetrydeck/sdk';
+import type TelemetryDeck from "@telemetrydeck/sdk";
+import type {
+  TelemetryDeckOptions,
+  TelemetryDeckPayload,
+} from "@telemetrydeck/sdk";
+import { inject } from "vue";
 
-export type TelemetryDeckMethod = 'signal' | 'queue' | 'flush';
+export type TelemetryDeckMethod = "signal" | "queue" | "flush";
 
 export interface TelemetryDeckErrorMeta {
   method: TelemetryDeckMethod;
@@ -17,8 +20,11 @@ export type TelemetryDeckErrorHandler = (
 ) => void | Promise<void>;
 
 export function useTelemetryDeck() {
-  const td = inject<TelemetryDeck>('td');
-  const onError = inject<TelemetryDeckErrorHandler | undefined>('tdOnError', undefined);
+  const td = inject<TelemetryDeck>("td");
+  const onError = inject<TelemetryDeckErrorHandler | undefined>(
+    "tdOnError",
+    undefined,
+  );
 
   const handleError = async (error: unknown, meta: TelemetryDeckErrorMeta) => {
     try {
@@ -34,11 +40,19 @@ export function useTelemetryDeck() {
     }
   };
 
-  const signal = async (type: string, payload?: TelemetryDeckPayload, options?: TelemetryDeckOptions) => {
+  const signal = async (
+    type: string,
+    payload?: TelemetryDeckPayload,
+    options?: TelemetryDeckOptions,
+  ) => {
     return td?.signal(type, payload, options);
   };
 
-  const queue = async (type: string, payload?: TelemetryDeckPayload, options?: TelemetryDeckOptions) => {
+  const queue = async (
+    type: string,
+    payload?: TelemetryDeckPayload,
+    options?: TelemetryDeckOptions,
+  ) => {
     return td?.queue(type, payload, options);
   };
 
@@ -46,19 +60,27 @@ export function useTelemetryDeck() {
     return td?.flush();
   };
 
-  const safeSignal = async (type: string, payload?: TelemetryDeckPayload, options?: TelemetryDeckOptions) => {
+  const safeSignal = async (
+    type: string,
+    payload?: TelemetryDeckPayload,
+    options?: TelemetryDeckOptions,
+  ) => {
     try {
       await td?.signal(type, payload, options);
     } catch (error) {
-      await handleError(error, { method: 'signal', type, payload, options });
+      await handleError(error, { method: "signal", type, payload, options });
     }
   };
 
-  const safeQueue = async (type: string, payload?: TelemetryDeckPayload, options?: TelemetryDeckOptions) => {
+  const safeQueue = async (
+    type: string,
+    payload?: TelemetryDeckPayload,
+    options?: TelemetryDeckOptions,
+  ) => {
     try {
       await td?.queue(type, payload, options);
     } catch (error) {
-      await handleError(error, { method: 'queue', type, payload, options });
+      await handleError(error, { method: "queue", type, payload, options });
     }
   };
 
@@ -66,7 +88,7 @@ export function useTelemetryDeck() {
     try {
       await td?.flush();
     } catch (error) {
-      await handleError(error, { method: 'flush' });
+      await handleError(error, { method: "flush" });
     }
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,20 +1,22 @@
-import { createApp } from 'vue'
-import './style.css'
-import App from './App.vue'
-import TelemetryDeckPlugin from '../index.ts'
+import { createApp } from "vue";
+import "./style.css";
+import TelemetryDeckPlugin from "../index.ts";
+import App from "./App.vue";
 
-const app = createApp(App)
+const app = createApp(App);
 app.use(TelemetryDeckPlugin, {
-  appID: import.meta.env.VITE_TELEMETRYDECK_APP_ID || 'test-app-id',
+  appID: import.meta.env.VITE_TELEMETRYDECK_APP_ID || "test-app-id",
   testMode: true,
   onError: (error, meta) => {
-    window.dispatchEvent(new CustomEvent('telemetrydeck:error', {
-      detail: {
-        message: error instanceof Error ? error.message : String(error),
-        meta,
-      },
-    }))
+    window.dispatchEvent(
+      new CustomEvent("telemetrydeck:error", {
+        detail: {
+          message: error instanceof Error ? error.message : String(error),
+          meta,
+        },
+      }),
+    );
   },
-})
+});
 
-app.mount('#app')
+app.mount("#app");

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,14 @@ const app = createApp(App)
 app.use(TelemetryDeckPlugin, {
   appID: import.meta.env.VITE_TELEMETRYDECK_APP_ID || 'test-app-id',
   testMode: true,
+  onError: (error, meta) => {
+    window.dispatchEvent(new CustomEvent('telemetrydeck:error', {
+      detail: {
+        message: error instanceof Error ? error.message : String(error),
+        meta,
+      },
+    }))
+  },
 })
 
 app.mount('#app')

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,5 +1,5 @@
 import TelemetryDeck from "@telemetrydeck/sdk";
-import type { TelemetryDeckErrorHandler } from '../hooks';
+import type { TelemetryDeckErrorHandler } from "../hooks";
 
 interface TelemetryDeckApp {
   provide: (key: string, value: unknown) => void;
@@ -18,16 +18,16 @@ export const plugin = {
     const [pluginOptions] = options;
 
     if (!pluginOptions?.appID) {
-      throw new Error('TelemetryDeck appID is required');
+      throw new Error("TelemetryDeck appID is required");
     }
 
     const td = new TelemetryDeck({
       appID: pluginOptions.appID,
-      clientUser: pluginOptions.clientUser || 'guest',
-      testMode: pluginOptions.testMode || false
+      clientUser: pluginOptions.clientUser || "guest",
+      testMode: pluginOptions.testMode || false,
     });
 
-    app.provide('td', td);
-    app.provide('tdOnError', pluginOptions.onError);
+    app.provide("td", td);
+    app.provide("tdOnError", pluginOptions.onError);
   },
 };

--- a/src/style.css
+++ b/src/style.css
@@ -1,9 +1,14 @@
 :root {
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
-  color: #162033;
   background: #f4f7fb;
+  color: #162033;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;

--- a/src/style.css
+++ b/src/style.css
@@ -1,79 +1,29 @@
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  color: #162033;
+  background: #f4f7fb;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  margin: 0;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-.card {
-  padding: 2em;
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  min-height: 100vh;
 }

--- a/src/tests/App.test.ts
+++ b/src/tests/App.test.ts
@@ -1,51 +1,30 @@
 import { mount } from '@vue/test-utils';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { nextTick } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import App from '../App.vue';
 
 const mockTelemetryDeck = {
   clientUser: '',
   signal: vi.fn(),
   queue: vi.fn(),
+  flush: vi.fn(),
 };
 
-// Mock the TelemetryDeck SDK
-vi.mock('@telemetrydeck/sdk', () => ({
-  default: () => mockTelemetryDeck,
-}));
+const waitForClickHandler = async () => {
+  await Promise.resolve();
+  await nextTick();
+};
 
 describe('App', () => {
   beforeEach(() => {
-    // Reset mock functions before each test
-    mockTelemetryDeck.signal.mockClear();
-    mockTelemetryDeck.queue.mockClear();
+    mockTelemetryDeck.signal.mockReset();
+    mockTelemetryDeck.queue.mockReset();
+    mockTelemetryDeck.flush.mockReset();
     mockTelemetryDeck.clientUser = 'test-user';
   });
 
-  it('renders the App and test buttons exist', async () => {
-    const wrapper = mount(App);
-
-    // Check if the component is rendered
-    expect(wrapper.find('a').attributes('href')).toBe('https://vitejs.dev');
-    expect(wrapper.find('.logo').exists()).toBe(true);
-
-    const signalClickButton = wrapper.find('#btnSignalClick');
-    const queueClickButton = wrapper.find('#btnQueueClick');
-    const signalClickButtonWithOptions = wrapper.find('#btnSignalClickWithOptions');
-    const queueClickButtonWithOptions = wrapper.find('#btnQueueClickWithOptions');
-    const setClientUserButton = wrapper.find('#btnSetClient');
-    expect(signalClickButton.exists()).toBe(true);
-    expect(queueClickButton.exists()).toBe(true);
-    expect(signalClickButtonWithOptions.exists()).toBe(true);
-    expect(queueClickButtonWithOptions.exists()).toBe(true);
-    expect(setClientUserButton.exists()).toBe(true);
-    expect(signalClickButton.text()).toBe('Log a click with signal');
-    expect(queueClickButton.text()).toBe('Log a click with queue');
-    expect(signalClickButtonWithOptions.text()).toBe('Log a click with signal with Options');
-    expect(queueClickButtonWithOptions.text()).toBe('Log a click with queue with Options');
-    expect(setClientUserButton.text()).toBe('Change user');
-  });
-
-  it('useTelementryDeck hook calls Telementry Deck correctly', async () => {
+  it('renders the demo controls', () => {
     const wrapper = mount(App, {
       global: {
         provide: {
@@ -54,37 +33,180 @@ describe('App', () => {
       },
     });
 
-    // Test button click event for buttonSignalClick
+    expect(wrapper.find('h1').text()).toBe('Demo controls');
+    expect(wrapper.find('#lastTelemetryAction').text()).toBe('');
+    expect(wrapper.find('#lastTelemetryResult').text()).toBe('');
+    expect(wrapper.find('#lastTelemetryError').text()).toBe('');
+
+    const buttons = [
+      ['#btnSignalClick', 'Send signal'],
+      ['#btnSignalClickWithOptions', 'Send signal with options'],
+      ['#btnQueueClick', 'Queue event'],
+      ['#btnQueueClickWithOptions', 'Queue event with options'],
+      ['#btnFlushClick', 'Flush queue'],
+      ['#btnSafeSignalClick', 'Safe signal'],
+      ['#btnSafeQueueClick', 'Safe queue'],
+      ['#btnSafeFlushClick', 'Safe flush'],
+      ['#btnSetClient', 'Change user'],
+      ['#btnClearStatus', 'Clear last action'],
+    ];
+
+    for (const [selector, label] of buttons) {
+      const button = wrapper.find(selector);
+      expect(button.exists()).toBe(true);
+      expect(button.text()).toBe(label);
+    }
+  });
+
+  it('calls TelemetryDeck methods from the demo controls', async () => {
+    const wrapper = mount(App, {
+      global: {
+        provide: {
+          td: mockTelemetryDeck,
+        },
+      },
+    });
+
+    mockTelemetryDeck.signal.mockResolvedValueOnce({ accepted: true });
+
     await wrapper.find('#btnSignalClick').trigger('click');
-    expect(mockTelemetryDeck.signal).toHaveBeenCalledTimes(1);
-    expect(mockTelemetryDeck.signal).toHaveBeenCalledWith('example_signal_event_name', { custom_data: 'other_data', timestamp: expect.any(String) }, undefined);
+    await waitForClickHandler();
+    expect(mockTelemetryDeck.signal).toHaveBeenCalledWith(
+      'example_signal_event_name',
+      expect.objectContaining({
+        custom_data: 'other_data',
+        source: 'signal',
+        timestamp: expect.any(String),
+      }),
+      undefined,
+    );
+    expect(wrapper.find('#lastTelemetryResult').text()).toBe('signal response: {"accepted":true}');
 
-    // Test button click event for buttonQueueClick
     await wrapper.find('#btnQueueClick').trigger('click');
-    expect(mockTelemetryDeck.queue).toHaveBeenCalledTimes(1);
-    expect(mockTelemetryDeck.queue).toHaveBeenCalledWith('example_queue_event_name', { custom_data: 'other_data', timestamp: expect.any(String) }, undefined);
+    await waitForClickHandler();
+    expect(mockTelemetryDeck.queue).toHaveBeenCalledWith(
+      'example_queue_event_name',
+      expect.objectContaining({
+        custom_data: 'other_data',
+        source: 'queue',
+        timestamp: expect.any(String),
+      }),
+      undefined,
+    );
+    expect(wrapper.find('#lastTelemetryResult').text()).toBe('queue promise resolved without response');
 
-    // Test button click event for buttonQueueClickWithOptions
     await wrapper.find('#btnQueueClickWithOptions').trigger('click');
-    expect(mockTelemetryDeck.queue).toHaveBeenCalledTimes(2);
-    expect(mockTelemetryDeck.queue).toHaveBeenCalledWith('example_queue_event_name_with_options', { custom_data: 'other_data', timestamp: expect.any(String) }, { testMode: true, clientUser: 'other_user', appID: "other_app_id" });
+    await waitForClickHandler();
+    expect(mockTelemetryDeck.queue).toHaveBeenCalledWith(
+      'example_queue_event_name_with_options',
+      expect.objectContaining({
+        custom_data: 'other_data',
+        source: 'queue_with_options',
+        timestamp: expect.any(String),
+      }),
+      { testMode: true, clientUser: 'other_user', appID: 'other_app_id' },
+    );
 
-    // Test button click event for buttonQueueClickWithOptions
     await wrapper.find('#btnSignalClickWithOptions').trigger('click');
-    expect(mockTelemetryDeck.signal).toHaveBeenCalledTimes(2);
-    expect(mockTelemetryDeck.signal).toHaveBeenCalledWith('example_signal_event_name_with_options', { custom_data: 'other_data', timestamp: expect.any(String) }, { testMode: true, clientUser: 'other_user', appID: "other_app_id" });
+    await waitForClickHandler();
+    expect(mockTelemetryDeck.signal).toHaveBeenCalledWith(
+      'example_signal_event_name_with_options',
+      expect.objectContaining({
+        custom_data: 'other_data',
+        source: 'signal_with_options',
+        timestamp: expect.any(String),
+      }),
+      { testMode: true, clientUser: 'other_user', appID: 'other_app_id' },
+    );
 
+    await wrapper.find('#btnFlushClick').trigger('click');
+    await waitForClickHandler();
+    expect(mockTelemetryDeck.flush).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('#lastTelemetryResult').text()).toBe('flush promise resolved without response');
 
-    // Test button click event for changeClientUserClick
-    let prevClientUser = mockTelemetryDeck.clientUser;
+    await wrapper.find('#btnSafeSignalClick').trigger('click');
+    await waitForClickHandler();
+    expect(mockTelemetryDeck.signal).toHaveBeenCalledWith(
+      'example_safe_signal_event_name',
+      expect.objectContaining({
+        source: 'safe_signal',
+      }),
+      undefined,
+    );
+    expect(wrapper.find('#lastTelemetryResult').text()).toBe('safeSignal promise resolved');
+
+    await wrapper.find('#btnSafeQueueClick').trigger('click');
+    await waitForClickHandler();
+    expect(mockTelemetryDeck.queue).toHaveBeenCalledWith(
+      'example_safe_queue_event_name',
+      expect.objectContaining({
+        source: 'safe_queue',
+      }),
+      undefined,
+    );
+
+    await wrapper.find('#btnSafeFlushClick').trigger('click');
+    await waitForClickHandler();
+    expect(mockTelemetryDeck.flush).toHaveBeenCalledTimes(2);
+    expect(wrapper.find('#lastTelemetryResult').text()).toBe('safeFlush promise resolved');
+
+    let previousClientUser = mockTelemetryDeck.clientUser;
     await wrapper.find('#btnSetClient').trigger('click');
+    await waitForClickHandler();
     expect(mockTelemetryDeck.clientUser).not.toBe('');
-    expect(mockTelemetryDeck.clientUser).not.toBe(prevClientUser); // check client user has changed
+    expect(mockTelemetryDeck.clientUser).not.toBe(previousClientUser);
 
-    // update user again
-    prevClientUser = mockTelemetryDeck.clientUser;
+    previousClientUser = mockTelemetryDeck.clientUser;
     await wrapper.find('#btnSetClient').trigger('click');
+    await waitForClickHandler();
     expect(mockTelemetryDeck.clientUser).not.toBe('');
-    expect(mockTelemetryDeck.clientUser).not.toBe(prevClientUser); // check client user has changed
+    expect(mockTelemetryDeck.clientUser).not.toBe(previousClientUser);
+    expect(wrapper.find('#lastTelemetryResult').text()).toBe('setClientUser completed');
+  });
+
+  it('displays TelemetryDeck errors captured by the demo onError handler', async () => {
+    const wrapper = mount(App, {
+      global: {
+        provide: {
+          td: mockTelemetryDeck,
+        },
+      },
+    });
+
+    window.dispatchEvent(new CustomEvent('telemetrydeck:error', {
+      detail: {
+        message: 'network failed',
+        meta: {
+          method: 'flush',
+        },
+      },
+    }));
+    await nextTick();
+
+    expect(wrapper.find('#lastTelemetryError').text()).toBe('flush failed: network failed');
+  });
+
+  it('displays raw method promise rejections', async () => {
+    mockTelemetryDeck.flush.mockRejectedValueOnce(new Error('flush failed'));
+    const wrapper = mount(App, {
+      global: {
+        provide: {
+          td: mockTelemetryDeck,
+        },
+      },
+    });
+
+    await wrapper.find('#btnFlushClick').trigger('click');
+    await waitForClickHandler();
+
+    expect(wrapper.find('#lastTelemetryResult').text()).toBe('flush rejected');
+    expect(wrapper.find('#lastTelemetryError').text()).toBe('flush failed: flush failed');
+
+    await wrapper.find('#btnClearStatus').trigger('click');
+    await nextTick();
+
+    expect(wrapper.find('#lastTelemetryAction').text()).toBe('');
+    expect(wrapper.find('#lastTelemetryResult').text()).toBe('');
+    expect(wrapper.find('#lastTelemetryError').text()).toBe('');
   });
 });

--- a/src/tests/App.test.ts
+++ b/src/tests/App.test.ts
@@ -16,6 +16,16 @@ const waitForClickHandler = async () => {
   await nextTick();
 };
 
+const mountApp = () => {
+  return mount(App, {
+    global: {
+      provide: {
+        td: mockTelemetryDeck,
+      },
+    },
+  });
+};
+
 describe('App', () => {
   beforeEach(() => {
     mockTelemetryDeck.signal.mockReset();
@@ -25,15 +35,10 @@ describe('App', () => {
   });
 
   it('renders the demo controls', () => {
-    const wrapper = mount(App, {
-      global: {
-        provide: {
-          td: mockTelemetryDeck,
-        },
-      },
-    });
+    const wrapper = mountApp();
 
     expect(wrapper.find('h1').text()).toBe('Demo controls');
+    expect(wrapper.find('#queuedTelemetryEvents').text()).toBe('0');
     expect(wrapper.find('#lastTelemetryAction').text()).toBe('');
     expect(wrapper.find('#lastTelemetryResult').text()).toBe('');
     expect(wrapper.find('#lastTelemetryError').text()).toBe('');
@@ -59,13 +64,7 @@ describe('App', () => {
   });
 
   it('calls TelemetryDeck methods from the demo controls', async () => {
-    const wrapper = mount(App, {
-      global: {
-        provide: {
-          td: mockTelemetryDeck,
-        },
-      },
-    });
+    const wrapper = mountApp();
 
     mockTelemetryDeck.signal.mockResolvedValueOnce({ accepted: true });
 
@@ -94,6 +93,7 @@ describe('App', () => {
       undefined,
     );
     expect(wrapper.find('#lastTelemetryResult').text()).toBe('queue promise resolved without response');
+    expect(wrapper.find('#queuedTelemetryEvents').text()).toBe('1');
 
     await wrapper.find('#btnQueueClickWithOptions').trigger('click');
     await waitForClickHandler();
@@ -123,6 +123,7 @@ describe('App', () => {
     await waitForClickHandler();
     expect(mockTelemetryDeck.flush).toHaveBeenCalledTimes(1);
     expect(wrapper.find('#lastTelemetryResult').text()).toBe('flush promise resolved without response');
+    expect(wrapper.find('#queuedTelemetryEvents').text()).toBe('0');
 
     await wrapper.find('#btnSafeSignalClick').trigger('click');
     await waitForClickHandler();
@@ -144,11 +145,14 @@ describe('App', () => {
       }),
       undefined,
     );
+    expect(wrapper.find('#lastTelemetryResult').text()).toBe('safeQueue promise resolved');
+    expect(wrapper.find('#queuedTelemetryEvents').text()).toBe('0');
 
     await wrapper.find('#btnSafeFlushClick').trigger('click');
     await waitForClickHandler();
     expect(mockTelemetryDeck.flush).toHaveBeenCalledTimes(2);
     expect(wrapper.find('#lastTelemetryResult').text()).toBe('safeFlush promise resolved');
+    expect(wrapper.find('#queuedTelemetryEvents').text()).toBe('0');
 
     let previousClientUser = mockTelemetryDeck.clientUser;
     await wrapper.find('#btnSetClient').trigger('click');
@@ -165,13 +169,7 @@ describe('App', () => {
   });
 
   it('displays TelemetryDeck errors captured by the demo onError handler', async () => {
-    const wrapper = mount(App, {
-      global: {
-        provide: {
-          td: mockTelemetryDeck,
-        },
-      },
-    });
+    const wrapper = mountApp();
 
     window.dispatchEvent(new CustomEvent('telemetrydeck:error', {
       detail: {
@@ -188,13 +186,7 @@ describe('App', () => {
 
   it('displays raw method promise rejections', async () => {
     mockTelemetryDeck.flush.mockRejectedValueOnce(new Error('flush failed'));
-    const wrapper = mount(App, {
-      global: {
-        provide: {
-          td: mockTelemetryDeck,
-        },
-      },
-    });
+    const wrapper = mountApp();
 
     await wrapper.find('#btnFlushClick').trigger('click');
     await waitForClickHandler();

--- a/src/tests/App.test.ts
+++ b/src/tests/App.test.ts
@@ -1,11 +1,10 @@
-import { mount } from '@vue/test-utils';
-import { nextTick } from 'vue';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-import App from '../App.vue';
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import App from "../App.vue";
 
 const mockTelemetryDeck = {
-  clientUser: '',
+  clientUser: "",
   signal: vi.fn(),
   queue: vi.fn(),
   flush: vi.fn(),
@@ -26,34 +25,34 @@ const mountApp = () => {
   });
 };
 
-describe('App', () => {
+describe("App", () => {
   beforeEach(() => {
     mockTelemetryDeck.signal.mockReset();
     mockTelemetryDeck.queue.mockReset();
     mockTelemetryDeck.flush.mockReset();
-    mockTelemetryDeck.clientUser = 'test-user';
+    mockTelemetryDeck.clientUser = "test-user";
   });
 
-  it('renders the demo controls', () => {
+  it("renders the demo controls", () => {
     const wrapper = mountApp();
 
-    expect(wrapper.find('h1').text()).toBe('Demo controls');
-    expect(wrapper.find('#queuedTelemetryEvents').text()).toBe('0');
-    expect(wrapper.find('#lastTelemetryAction').text()).toBe('');
-    expect(wrapper.find('#lastTelemetryResult').text()).toBe('');
-    expect(wrapper.find('#lastTelemetryError').text()).toBe('');
+    expect(wrapper.find("h1").text()).toBe("Demo controls");
+    expect(wrapper.find("#queuedTelemetryEvents").text()).toBe("0");
+    expect(wrapper.find("#lastTelemetryAction").text()).toBe("");
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe("");
+    expect(wrapper.find("#lastTelemetryError").text()).toBe("");
 
     const buttons = [
-      ['#btnSignalClick', 'Send signal'],
-      ['#btnSignalClickWithOptions', 'Send signal with options'],
-      ['#btnQueueClick', 'Queue event'],
-      ['#btnQueueClickWithOptions', 'Queue event with options'],
-      ['#btnFlushClick', 'Flush queue'],
-      ['#btnSafeSignalClick', 'Safe signal'],
-      ['#btnSafeQueueClick', 'Safe queue'],
-      ['#btnSafeFlushClick', 'Safe flush'],
-      ['#btnSetClient', 'Change user'],
-      ['#btnClearStatus', 'Clear last action'],
+      ["#btnSignalClick", "Send signal"],
+      ["#btnSignalClickWithOptions", "Send signal with options"],
+      ["#btnQueueClick", "Queue event"],
+      ["#btnQueueClickWithOptions", "Queue event with options"],
+      ["#btnFlushClick", "Flush queue"],
+      ["#btnSafeSignalClick", "Safe signal"],
+      ["#btnSafeQueueClick", "Safe queue"],
+      ["#btnSafeFlushClick", "Safe flush"],
+      ["#btnSetClient", "Change user"],
+      ["#btnClearStatus", "Clear last action"],
     ];
 
     for (const [selector, label] of buttons) {
@@ -63,142 +62,162 @@ describe('App', () => {
     }
   });
 
-  it('calls TelemetryDeck methods from the demo controls', async () => {
+  it("calls TelemetryDeck methods from the demo controls", async () => {
     const wrapper = mountApp();
 
     mockTelemetryDeck.signal.mockResolvedValueOnce({ accepted: true });
 
-    await wrapper.find('#btnSignalClick').trigger('click');
+    await wrapper.find("#btnSignalClick").trigger("click");
     await waitForClickHandler();
     expect(mockTelemetryDeck.signal).toHaveBeenCalledWith(
-      'example_signal_event_name',
+      "example_signal_event_name",
       expect.objectContaining({
-        custom_data: 'other_data',
-        source: 'signal',
+        custom_data: "other_data",
+        source: "signal",
         timestamp: expect.any(String),
       }),
       undefined,
     );
-    expect(wrapper.find('#lastTelemetryResult').text()).toBe('signal response: {"accepted":true}');
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      'signal response: {"accepted":true}',
+    );
 
-    await wrapper.find('#btnQueueClick').trigger('click');
+    await wrapper.find("#btnQueueClick").trigger("click");
     await waitForClickHandler();
     expect(mockTelemetryDeck.queue).toHaveBeenCalledWith(
-      'example_queue_event_name',
+      "example_queue_event_name",
       expect.objectContaining({
-        custom_data: 'other_data',
-        source: 'queue',
+        custom_data: "other_data",
+        source: "queue",
         timestamp: expect.any(String),
       }),
       undefined,
     );
-    expect(wrapper.find('#lastTelemetryResult').text()).toBe('queue promise resolved without response');
-    expect(wrapper.find('#queuedTelemetryEvents').text()).toBe('1');
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      "queue promise resolved without response",
+    );
+    expect(wrapper.find("#queuedTelemetryEvents").text()).toBe("1");
 
-    await wrapper.find('#btnQueueClickWithOptions').trigger('click');
+    await wrapper.find("#btnQueueClickWithOptions").trigger("click");
     await waitForClickHandler();
     expect(mockTelemetryDeck.queue).toHaveBeenCalledWith(
-      'example_queue_event_name_with_options',
+      "example_queue_event_name_with_options",
       expect.objectContaining({
-        custom_data: 'other_data',
-        source: 'queue_with_options',
+        custom_data: "other_data",
+        source: "queue_with_options",
         timestamp: expect.any(String),
       }),
-      { testMode: true, clientUser: 'other_user', appID: 'other_app_id' },
+      { testMode: true, clientUser: "other_user", appID: "other_app_id" },
     );
 
-    await wrapper.find('#btnSignalClickWithOptions').trigger('click');
+    await wrapper.find("#btnSignalClickWithOptions").trigger("click");
     await waitForClickHandler();
     expect(mockTelemetryDeck.signal).toHaveBeenCalledWith(
-      'example_signal_event_name_with_options',
+      "example_signal_event_name_with_options",
       expect.objectContaining({
-        custom_data: 'other_data',
-        source: 'signal_with_options',
+        custom_data: "other_data",
+        source: "signal_with_options",
         timestamp: expect.any(String),
       }),
-      { testMode: true, clientUser: 'other_user', appID: 'other_app_id' },
+      { testMode: true, clientUser: "other_user", appID: "other_app_id" },
     );
 
-    await wrapper.find('#btnFlushClick').trigger('click');
+    await wrapper.find("#btnFlushClick").trigger("click");
     await waitForClickHandler();
     expect(mockTelemetryDeck.flush).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('#lastTelemetryResult').text()).toBe('flush promise resolved without response');
-    expect(wrapper.find('#queuedTelemetryEvents').text()).toBe('0');
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      "flush promise resolved without response",
+    );
+    expect(wrapper.find("#queuedTelemetryEvents").text()).toBe("0");
 
-    await wrapper.find('#btnSafeSignalClick').trigger('click');
+    await wrapper.find("#btnSafeSignalClick").trigger("click");
     await waitForClickHandler();
     expect(mockTelemetryDeck.signal).toHaveBeenCalledWith(
-      'example_safe_signal_event_name',
+      "example_safe_signal_event_name",
       expect.objectContaining({
-        source: 'safe_signal',
+        source: "safe_signal",
       }),
       undefined,
     );
-    expect(wrapper.find('#lastTelemetryResult').text()).toBe('safeSignal promise resolved');
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      "safeSignal promise resolved",
+    );
 
-    await wrapper.find('#btnSafeQueueClick').trigger('click');
+    await wrapper.find("#btnSafeQueueClick").trigger("click");
     await waitForClickHandler();
     expect(mockTelemetryDeck.queue).toHaveBeenCalledWith(
-      'example_safe_queue_event_name',
+      "example_safe_queue_event_name",
       expect.objectContaining({
-        source: 'safe_queue',
+        source: "safe_queue",
       }),
       undefined,
     );
-    expect(wrapper.find('#lastTelemetryResult').text()).toBe('safeQueue promise resolved');
-    expect(wrapper.find('#queuedTelemetryEvents').text()).toBe('0');
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      "safeQueue promise resolved",
+    );
+    expect(wrapper.find("#queuedTelemetryEvents").text()).toBe("0");
 
-    await wrapper.find('#btnSafeFlushClick').trigger('click');
+    await wrapper.find("#btnSafeFlushClick").trigger("click");
     await waitForClickHandler();
     expect(mockTelemetryDeck.flush).toHaveBeenCalledTimes(2);
-    expect(wrapper.find('#lastTelemetryResult').text()).toBe('safeFlush promise resolved');
-    expect(wrapper.find('#queuedTelemetryEvents').text()).toBe('0');
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      "safeFlush promise resolved",
+    );
+    expect(wrapper.find("#queuedTelemetryEvents").text()).toBe("0");
 
     let previousClientUser = mockTelemetryDeck.clientUser;
-    await wrapper.find('#btnSetClient').trigger('click');
+    await wrapper.find("#btnSetClient").trigger("click");
     await waitForClickHandler();
-    expect(mockTelemetryDeck.clientUser).not.toBe('');
+    expect(mockTelemetryDeck.clientUser).not.toBe("");
     expect(mockTelemetryDeck.clientUser).not.toBe(previousClientUser);
 
     previousClientUser = mockTelemetryDeck.clientUser;
-    await wrapper.find('#btnSetClient').trigger('click');
+    await wrapper.find("#btnSetClient").trigger("click");
     await waitForClickHandler();
-    expect(mockTelemetryDeck.clientUser).not.toBe('');
+    expect(mockTelemetryDeck.clientUser).not.toBe("");
     expect(mockTelemetryDeck.clientUser).not.toBe(previousClientUser);
-    expect(wrapper.find('#lastTelemetryResult').text()).toBe('setClientUser completed');
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      "setClientUser completed",
+    );
   });
 
-  it('displays TelemetryDeck errors captured by the demo onError handler', async () => {
+  it("displays TelemetryDeck errors captured by the demo onError handler", async () => {
     const wrapper = mountApp();
 
-    window.dispatchEvent(new CustomEvent('telemetrydeck:error', {
-      detail: {
-        message: 'network failed',
-        meta: {
-          method: 'flush',
+    window.dispatchEvent(
+      new CustomEvent("telemetrydeck:error", {
+        detail: {
+          message: "network failed",
+          meta: {
+            method: "flush",
+          },
         },
-      },
-    }));
+      }),
+    );
     await nextTick();
 
-    expect(wrapper.find('#lastTelemetryError').text()).toBe('flush failed: network failed');
+    expect(wrapper.find("#lastTelemetryError").text()).toBe(
+      "flush failed: network failed",
+    );
   });
 
-  it('displays raw method promise rejections', async () => {
-    mockTelemetryDeck.flush.mockRejectedValueOnce(new Error('flush failed'));
+  it("displays raw method promise rejections", async () => {
+    mockTelemetryDeck.flush.mockRejectedValueOnce(new Error("flush failed"));
     const wrapper = mountApp();
 
-    await wrapper.find('#btnFlushClick').trigger('click');
+    await wrapper.find("#btnFlushClick").trigger("click");
     await waitForClickHandler();
 
-    expect(wrapper.find('#lastTelemetryResult').text()).toBe('flush rejected');
-    expect(wrapper.find('#lastTelemetryError').text()).toBe('flush failed: flush failed');
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe("flush rejected");
+    expect(wrapper.find("#lastTelemetryError").text()).toBe(
+      "flush failed: flush failed",
+    );
 
-    await wrapper.find('#btnClearStatus').trigger('click');
+    await wrapper.find("#btnClearStatus").trigger("click");
     await nextTick();
 
-    expect(wrapper.find('#lastTelemetryAction').text()).toBe('');
-    expect(wrapper.find('#lastTelemetryResult').text()).toBe('');
-    expect(wrapper.find('#lastTelemetryError').text()).toBe('');
+    expect(wrapper.find("#lastTelemetryAction").text()).toBe("");
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe("");
+    expect(wrapper.find("#lastTelemetryError").text()).toBe("");
   });
 });

--- a/src/tests/App.test.ts
+++ b/src/tests/App.test.ts
@@ -12,6 +12,7 @@ const mockTelemetryDeck = {
 
 const waitForClickHandler = async () => {
   await Promise.resolve();
+  await Promise.resolve();
   await nextTick();
 };
 

--- a/src/tests/App.test.ts
+++ b/src/tests/App.test.ts
@@ -1,9 +1,10 @@
-import { mount } from "@vue/test-utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 import App from "../App.vue";
 
 let queuedSignals: unknown[] = [];
+const mountedWrappers: VueWrapper[] = [];
 
 const mockTelemetryDeck = {
   clientUser: "guest",
@@ -22,7 +23,7 @@ const waitForClickHandler = async () => {
 };
 
 const mountApp = (provide: Record<string, unknown> = {}) => {
-  return mount(App, {
+  const wrapper = mount(App, {
     global: {
       provide: {
         td: mockTelemetryDeck,
@@ -30,6 +31,8 @@ const mountApp = (provide: Record<string, unknown> = {}) => {
       },
     },
   });
+  mountedWrappers.push(wrapper);
+  return wrapper;
 };
 
 describe("App", () => {
@@ -46,6 +49,13 @@ describe("App", () => {
     mockTelemetryDeck.flush.mockImplementation(async () => {
       queuedSignals = [];
     });
+  });
+
+  afterEach(() => {
+    for (const wrapper of mountedWrappers) {
+      wrapper.unmount();
+    }
+    mountedWrappers.length = 0;
   });
 
   it("renders the demo controls", () => {
@@ -225,6 +235,23 @@ describe("App", () => {
     await waitForClickHandler();
 
     expect(wrapper.find("#lastTelemetryResult").text()).toBe("flush rejected");
+    expect(wrapper.find("#lastTelemetryError").text()).toBe(
+      "flush failed: flush failed",
+    );
+
+    await wrapper.find("#btnSetClient").trigger("click");
+    await waitForClickHandler();
+
+    expect(wrapper.find("#lastTelemetryAction").text()).toBe("Change user");
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      "setClientUser completed",
+    );
+    expect(wrapper.find("#lastTelemetryError").text()).toBe("");
+
+    mockTelemetryDeck.flush.mockRejectedValueOnce(new Error("flush failed"));
+    await wrapper.find("#btnFlushClick").trigger("click");
+    await waitForClickHandler();
+
     expect(wrapper.find("#lastTelemetryError").text()).toBe(
       "flush failed: flush failed",
     );

--- a/src/tests/App.test.ts
+++ b/src/tests/App.test.ts
@@ -3,11 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 import App from "../App.vue";
 
+let queuedSignals: unknown[] = [];
+
 const mockTelemetryDeck = {
   clientUser: "guest",
   signal: vi.fn(),
   queue: vi.fn(),
   flush: vi.fn(),
+  store: {
+    values: vi.fn(() => queuedSignals),
+  },
 };
 
 const waitForClickHandler = async () => {
@@ -16,11 +21,12 @@ const waitForClickHandler = async () => {
   await nextTick();
 };
 
-const mountApp = () => {
+const mountApp = (provide: Record<string, unknown> = {}) => {
   return mount(App, {
     global: {
       provide: {
         td: mockTelemetryDeck,
+        ...provide,
       },
     },
   });
@@ -31,7 +37,15 @@ describe("App", () => {
     mockTelemetryDeck.signal.mockReset();
     mockTelemetryDeck.queue.mockReset();
     mockTelemetryDeck.flush.mockReset();
+    mockTelemetryDeck.store.values.mockClear();
     mockTelemetryDeck.clientUser = "guest";
+    queuedSignals = [];
+    mockTelemetryDeck.queue.mockImplementation(async () => {
+      queuedSignals.push({});
+    });
+    mockTelemetryDeck.flush.mockImplementation(async () => {
+      queuedSignals = [];
+    });
   });
 
   it("renders the demo controls", () => {
@@ -157,7 +171,7 @@ describe("App", () => {
     expect(wrapper.find("#lastTelemetryResult").text()).toBe(
       "safeQueue promise resolved",
     );
-    expect(wrapper.find("#queuedTelemetryEvents").text()).toBe("0");
+    expect(wrapper.find("#queuedTelemetryEvents").text()).toBe("1");
 
     await wrapper.find("#btnSafeFlushClick").trigger("click");
     await waitForClickHandler();
@@ -231,6 +245,33 @@ describe("App", () => {
     expect(wrapper.find("#lastTelemetryError").text()).toBe("");
   });
 
+  it("does not increment the queue count when safe queue captures an error", async () => {
+    mockTelemetryDeck.queue.mockRejectedValueOnce(new Error("queue failed"));
+    const wrapper = mountApp({
+      tdOnError: (error: unknown, meta: unknown) => {
+        window.dispatchEvent(
+          new CustomEvent("telemetrydeck:error", {
+            detail: {
+              message: error instanceof Error ? error.message : String(error),
+              meta,
+            },
+          }),
+        );
+      },
+    });
+
+    await wrapper.find("#btnSafeQueueClick").trigger("click");
+    await waitForClickHandler();
+
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      "safeQueue promise resolved",
+    );
+    expect(wrapper.find("#lastTelemetryError").text()).toBe(
+      "queue: example_safe_queue_event_name failed: queue failed",
+    );
+    expect(wrapper.find("#queuedTelemetryEvents").text()).toBe("0");
+  });
+
   it("updates safe action status while the promise is pending", async () => {
     let resolveSignal: () => void = () => {};
     mockTelemetryDeck.signal.mockReturnValueOnce(
@@ -243,9 +284,7 @@ describe("App", () => {
     await wrapper.find("#btnSafeSignalClick").trigger("click");
     await nextTick();
 
-    expect(wrapper.find("#lastTelemetryAction").text()).toBe(
-      "Safe signal completed",
-    );
+    expect(wrapper.find("#lastTelemetryAction").text()).toBe("Safe signal");
     expect(wrapper.find("#lastTelemetryResult").text()).toBe("");
 
     resolveSignal();

--- a/src/tests/App.test.ts
+++ b/src/tests/App.test.ts
@@ -4,7 +4,7 @@ import { nextTick } from "vue";
 import App from "../App.vue";
 
 const mockTelemetryDeck = {
-  clientUser: "",
+  clientUser: "guest",
   signal: vi.fn(),
   queue: vi.fn(),
   flush: vi.fn(),
@@ -30,13 +30,14 @@ describe("App", () => {
     mockTelemetryDeck.signal.mockReset();
     mockTelemetryDeck.queue.mockReset();
     mockTelemetryDeck.flush.mockReset();
-    mockTelemetryDeck.clientUser = "test-user";
+    mockTelemetryDeck.clientUser = "guest";
   });
 
   it("renders the demo controls", () => {
     const wrapper = mountApp();
 
     expect(wrapper.find("h1").text()).toBe("Demo controls");
+    expect(mockTelemetryDeck.clientUser).toBe("guest");
     expect(wrapper.find("#queuedTelemetryEvents").text()).toBe("0");
     expect(wrapper.find("#lastTelemetryAction").text()).toBe("");
     expect(wrapper.find("#lastTelemetryResult").text()).toBe("");
@@ -213,11 +214,44 @@ describe("App", () => {
       "flush failed: flush failed",
     );
 
+    await wrapper.find("#btnFlushClick").trigger("click");
+    await waitForClickHandler();
+
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      "flush promise resolved without response",
+    );
+    expect(wrapper.find("#lastTelemetryError").text()).toBe("");
+
     await wrapper.find("#btnClearStatus").trigger("click");
     await nextTick();
 
     expect(wrapper.find("#lastTelemetryAction").text()).toBe("");
     expect(wrapper.find("#lastTelemetryResult").text()).toBe("");
     expect(wrapper.find("#lastTelemetryError").text()).toBe("");
+  });
+
+  it("updates safe action status while the promise is pending", async () => {
+    let resolveSignal: () => void = () => {};
+    mockTelemetryDeck.signal.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveSignal = resolve;
+      }),
+    );
+    const wrapper = mountApp();
+
+    await wrapper.find("#btnSafeSignalClick").trigger("click");
+    await nextTick();
+
+    expect(wrapper.find("#lastTelemetryAction").text()).toBe(
+      "Safe signal completed",
+    );
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe("");
+
+    resolveSignal();
+    await waitForClickHandler();
+
+    expect(wrapper.find("#lastTelemetryResult").text()).toBe(
+      "safeSignal promise resolved",
+    );
   });
 });

--- a/src/tests/hooks.test.ts
+++ b/src/tests/hooks.test.ts
@@ -8,6 +8,9 @@ const mockTelemetryDeck = {
   signal: vi.fn(),
   queue: vi.fn(),
   flush: vi.fn(),
+  store: {
+    values: vi.fn(() => []),
+  },
 };
 
 const HookConsumer = defineComponent({
@@ -23,6 +26,8 @@ describe("useTelemetryDeck safe methods", () => {
     mockTelemetryDeck.signal.mockReset();
     mockTelemetryDeck.queue.mockReset();
     mockTelemetryDeck.flush.mockReset();
+    mockTelemetryDeck.store.values.mockReset();
+    mockTelemetryDeck.store.values.mockReturnValue([]);
   });
 
   it("swallows rejected promises in safe methods and calls onError", async () => {
@@ -180,5 +185,20 @@ describe("useTelemetryDeck safe methods", () => {
     await expect(vm.signal("ui.opened")).rejects.toBe(signalError);
     await expect(vm.queue("button.clicked")).rejects.toBe(queueError);
     await expect(vm.flush()).rejects.toBe(flushError);
+  });
+
+  it("returns the current sdk queue count", () => {
+    mockTelemetryDeck.store.values.mockReturnValue([{}, {}]);
+
+    const wrapper = mount(HookConsumer, {
+      global: {
+        provide: {
+          td: mockTelemetryDeck,
+        },
+      },
+    });
+    const vm = wrapper.vm as unknown as ReturnType<typeof useTelemetryDeck>;
+
+    expect(vm.getQueueCount()).toBe(2);
   });
 });

--- a/src/tests/hooks.test.ts
+++ b/src/tests/hooks.test.ts
@@ -1,37 +1,37 @@
-import { mount } from '@vue/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { defineComponent } from 'vue';
-import { useTelemetryDeck } from '../hooks';
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent } from "vue";
+import { useTelemetryDeck } from "../hooks";
 
 const mockTelemetryDeck = {
-  clientUser: 'test-user',
+  clientUser: "test-user",
   signal: vi.fn(),
   queue: vi.fn(),
   flush: vi.fn(),
 };
 
 const HookConsumer = defineComponent({
-  name: 'HookConsumer',
+  name: "HookConsumer",
   setup() {
     return useTelemetryDeck();
   },
-  template: '<div />',
+  template: "<div />",
 });
 
-describe('useTelemetryDeck safe methods', () => {
+describe("useTelemetryDeck safe methods", () => {
   beforeEach(() => {
     mockTelemetryDeck.signal.mockReset();
     mockTelemetryDeck.queue.mockReset();
     mockTelemetryDeck.flush.mockReset();
   });
 
-  it('swallows rejected promises in safe methods and calls onError', async () => {
-    const signalError = new Error('signal failed');
-    const queueError = new Error('queue failed');
-    const flushError = new Error('flush failed');
-    const signalPayload = { feature: 'home' };
-    const queuePayload = { action: 'tap' };
-    const queueOptions = { appID: 'other-app-id', clientUser: 'other-user' };
+  it("swallows rejected promises in safe methods and calls onError", async () => {
+    const signalError = new Error("signal failed");
+    const queueError = new Error("queue failed");
+    const flushError = new Error("flush failed");
+    const signalPayload = { feature: "home" };
+    const queuePayload = { action: "tap" };
+    const queueOptions = { appID: "other-app-id", clientUser: "other-user" };
     const onError = vi.fn();
 
     mockTelemetryDeck.signal.mockRejectedValueOnce(signalError);
@@ -48,33 +48,37 @@ describe('useTelemetryDeck safe methods', () => {
     });
     const vm = wrapper.vm as unknown as ReturnType<typeof useTelemetryDeck>;
 
-    await expect(vm.safeSignal('ui.opened', signalPayload)).resolves.toBeUndefined();
-    await expect(vm.safeQueue('button.clicked', queuePayload, queueOptions)).resolves.toBeUndefined();
+    await expect(
+      vm.safeSignal("ui.opened", signalPayload),
+    ).resolves.toBeUndefined();
+    await expect(
+      vm.safeQueue("button.clicked", queuePayload, queueOptions),
+    ).resolves.toBeUndefined();
     await expect(vm.safeFlush()).resolves.toBeUndefined();
     expect(onError).toHaveBeenCalledTimes(3);
     expect(onError).toHaveBeenNthCalledWith(1, signalError, {
-      method: 'signal',
-      type: 'ui.opened',
+      method: "signal",
+      type: "ui.opened",
       payload: signalPayload,
       options: undefined,
     });
     expect(onError).toHaveBeenNthCalledWith(2, queueError, {
-      method: 'queue',
-      type: 'button.clicked',
+      method: "queue",
+      type: "button.clicked",
       payload: queuePayload,
       options: queueOptions,
     });
     expect(onError).toHaveBeenNthCalledWith(3, flushError, {
-      method: 'flush',
+      method: "flush",
     });
   });
 
-  it('still resolves safe methods when onError throws', async () => {
-    const signalError = new Error('signal failed');
-    const queueError = new Error('queue failed');
-    const flushError = new Error('flush failed');
+  it("still resolves safe methods when onError throws", async () => {
+    const signalError = new Error("signal failed");
+    const queueError = new Error("queue failed");
+    const flushError = new Error("flush failed");
     const onError = vi.fn(() => {
-      throw new Error('onError failed');
+      throw new Error("onError failed");
     });
 
     mockTelemetryDeck.signal.mockRejectedValueOnce(signalError);
@@ -91,33 +95,33 @@ describe('useTelemetryDeck safe methods', () => {
     });
     const vm = wrapper.vm as unknown as ReturnType<typeof useTelemetryDeck>;
 
-    await expect(vm.safeSignal('ui.opened')).resolves.toBeUndefined();
-    await expect(vm.safeQueue('button.clicked')).resolves.toBeUndefined();
+    await expect(vm.safeSignal("ui.opened")).resolves.toBeUndefined();
+    await expect(vm.safeQueue("button.clicked")).resolves.toBeUndefined();
     await expect(vm.safeFlush()).resolves.toBeUndefined();
     expect(onError).toHaveBeenCalledTimes(3);
     expect(onError).toHaveBeenNthCalledWith(1, signalError, {
-      method: 'signal',
-      type: 'ui.opened',
+      method: "signal",
+      type: "ui.opened",
       payload: undefined,
       options: undefined,
     });
     expect(onError).toHaveBeenNthCalledWith(2, queueError, {
-      method: 'queue',
-      type: 'button.clicked',
+      method: "queue",
+      type: "button.clicked",
       payload: undefined,
       options: undefined,
     });
     expect(onError).toHaveBeenNthCalledWith(3, flushError, {
-      method: 'flush',
+      method: "flush",
     });
   });
 
-  it('still resolves safe methods when onError rejects asynchronously', async () => {
-    const signalError = new Error('signal failed');
-    const queueError = new Error('queue failed');
-    const flushError = new Error('flush failed');
+  it("still resolves safe methods when onError rejects asynchronously", async () => {
+    const signalError = new Error("signal failed");
+    const queueError = new Error("queue failed");
+    const flushError = new Error("flush failed");
     const onError = vi.fn(async () => {
-      throw new Error('onError async failed');
+      throw new Error("onError async failed");
     });
 
     mockTelemetryDeck.signal.mockRejectedValueOnce(signalError);
@@ -134,31 +138,31 @@ describe('useTelemetryDeck safe methods', () => {
     });
     const vm = wrapper.vm as unknown as ReturnType<typeof useTelemetryDeck>;
 
-    await expect(vm.safeSignal('ui.opened')).resolves.toBeUndefined();
-    await expect(vm.safeQueue('button.clicked')).resolves.toBeUndefined();
+    await expect(vm.safeSignal("ui.opened")).resolves.toBeUndefined();
+    await expect(vm.safeQueue("button.clicked")).resolves.toBeUndefined();
     await expect(vm.safeFlush()).resolves.toBeUndefined();
     expect(onError).toHaveBeenCalledTimes(3);
     expect(onError).toHaveBeenNthCalledWith(1, signalError, {
-      method: 'signal',
-      type: 'ui.opened',
+      method: "signal",
+      type: "ui.opened",
       payload: undefined,
       options: undefined,
     });
     expect(onError).toHaveBeenNthCalledWith(2, queueError, {
-      method: 'queue',
-      type: 'button.clicked',
+      method: "queue",
+      type: "button.clicked",
       payload: undefined,
       options: undefined,
     });
     expect(onError).toHaveBeenNthCalledWith(3, flushError, {
-      method: 'flush',
+      method: "flush",
     });
   });
 
-  it('keeps raw methods rejecting so callers can handle errors explicitly', async () => {
-    const signalError = new Error('raw signal failed');
-    const queueError = new Error('raw queue failed');
-    const flushError = new Error('raw flush failed');
+  it("keeps raw methods rejecting so callers can handle errors explicitly", async () => {
+    const signalError = new Error("raw signal failed");
+    const queueError = new Error("raw queue failed");
+    const flushError = new Error("raw flush failed");
 
     mockTelemetryDeck.signal.mockRejectedValueOnce(signalError);
     mockTelemetryDeck.queue.mockRejectedValueOnce(queueError);
@@ -173,8 +177,8 @@ describe('useTelemetryDeck safe methods', () => {
     });
     const vm = wrapper.vm as unknown as ReturnType<typeof useTelemetryDeck>;
 
-    await expect(vm.signal('ui.opened')).rejects.toBe(signalError);
-    await expect(vm.queue('button.clicked')).rejects.toBe(queueError);
+    await expect(vm.signal("ui.opened")).rejects.toBe(signalError);
+    await expect(vm.queue("button.clicked")).rejects.toBe(queueError);
     await expect(vm.flush()).rejects.toBe(flushError);
   });
 });

--- a/src/tests/hooks.test.ts
+++ b/src/tests/hooks.test.ts
@@ -7,6 +7,7 @@ const mockTelemetryDeck = {
   clientUser: 'test-user',
   signal: vi.fn(),
   queue: vi.fn(),
+  flush: vi.fn(),
 };
 
 const HookConsumer = defineComponent({
@@ -21,11 +22,13 @@ describe('useTelemetryDeck safe methods', () => {
   beforeEach(() => {
     mockTelemetryDeck.signal.mockReset();
     mockTelemetryDeck.queue.mockReset();
+    mockTelemetryDeck.flush.mockReset();
   });
 
   it('swallows rejected promises in safe methods and calls onError', async () => {
     const signalError = new Error('signal failed');
     const queueError = new Error('queue failed');
+    const flushError = new Error('flush failed');
     const signalPayload = { feature: 'home' };
     const queuePayload = { action: 'tap' };
     const queueOptions = { appID: 'other-app-id', clientUser: 'other-user' };
@@ -33,6 +36,7 @@ describe('useTelemetryDeck safe methods', () => {
 
     mockTelemetryDeck.signal.mockRejectedValueOnce(signalError);
     mockTelemetryDeck.queue.mockRejectedValueOnce(queueError);
+    mockTelemetryDeck.flush.mockRejectedValueOnce(flushError);
 
     const wrapper = mount(HookConsumer, {
       global: {
@@ -46,7 +50,8 @@ describe('useTelemetryDeck safe methods', () => {
 
     await expect(vm.safeSignal('ui.opened', signalPayload)).resolves.toBeUndefined();
     await expect(vm.safeQueue('button.clicked', queuePayload, queueOptions)).resolves.toBeUndefined();
-    expect(onError).toHaveBeenCalledTimes(2);
+    await expect(vm.safeFlush()).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledTimes(3);
     expect(onError).toHaveBeenNthCalledWith(1, signalError, {
       method: 'signal',
       type: 'ui.opened',
@@ -59,17 +64,22 @@ describe('useTelemetryDeck safe methods', () => {
       payload: queuePayload,
       options: queueOptions,
     });
+    expect(onError).toHaveBeenNthCalledWith(3, flushError, {
+      method: 'flush',
+    });
   });
 
   it('still resolves safe methods when onError throws', async () => {
     const signalError = new Error('signal failed');
     const queueError = new Error('queue failed');
+    const flushError = new Error('flush failed');
     const onError = vi.fn(() => {
       throw new Error('onError failed');
     });
 
     mockTelemetryDeck.signal.mockRejectedValueOnce(signalError);
     mockTelemetryDeck.queue.mockRejectedValueOnce(queueError);
+    mockTelemetryDeck.flush.mockRejectedValueOnce(flushError);
 
     const wrapper = mount(HookConsumer, {
       global: {
@@ -83,7 +93,8 @@ describe('useTelemetryDeck safe methods', () => {
 
     await expect(vm.safeSignal('ui.opened')).resolves.toBeUndefined();
     await expect(vm.safeQueue('button.clicked')).resolves.toBeUndefined();
-    expect(onError).toHaveBeenCalledTimes(2);
+    await expect(vm.safeFlush()).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledTimes(3);
     expect(onError).toHaveBeenNthCalledWith(1, signalError, {
       method: 'signal',
       type: 'ui.opened',
@@ -95,18 +106,23 @@ describe('useTelemetryDeck safe methods', () => {
       type: 'button.clicked',
       payload: undefined,
       options: undefined,
+    });
+    expect(onError).toHaveBeenNthCalledWith(3, flushError, {
+      method: 'flush',
     });
   });
 
   it('still resolves safe methods when onError rejects asynchronously', async () => {
     const signalError = new Error('signal failed');
     const queueError = new Error('queue failed');
+    const flushError = new Error('flush failed');
     const onError = vi.fn(async () => {
       throw new Error('onError async failed');
     });
 
     mockTelemetryDeck.signal.mockRejectedValueOnce(signalError);
     mockTelemetryDeck.queue.mockRejectedValueOnce(queueError);
+    mockTelemetryDeck.flush.mockRejectedValueOnce(flushError);
 
     const wrapper = mount(HookConsumer, {
       global: {
@@ -120,7 +136,8 @@ describe('useTelemetryDeck safe methods', () => {
 
     await expect(vm.safeSignal('ui.opened')).resolves.toBeUndefined();
     await expect(vm.safeQueue('button.clicked')).resolves.toBeUndefined();
-    expect(onError).toHaveBeenCalledTimes(2);
+    await expect(vm.safeFlush()).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledTimes(3);
     expect(onError).toHaveBeenNthCalledWith(1, signalError, {
       method: 'signal',
       type: 'ui.opened',
@@ -133,14 +150,19 @@ describe('useTelemetryDeck safe methods', () => {
       payload: undefined,
       options: undefined,
     });
+    expect(onError).toHaveBeenNthCalledWith(3, flushError, {
+      method: 'flush',
+    });
   });
 
   it('keeps raw methods rejecting so callers can handle errors explicitly', async () => {
     const signalError = new Error('raw signal failed');
     const queueError = new Error('raw queue failed');
+    const flushError = new Error('raw flush failed');
 
     mockTelemetryDeck.signal.mockRejectedValueOnce(signalError);
     mockTelemetryDeck.queue.mockRejectedValueOnce(queueError);
+    mockTelemetryDeck.flush.mockRejectedValueOnce(flushError);
 
     const wrapper = mount(HookConsumer, {
       global: {
@@ -153,5 +175,6 @@ describe('useTelemetryDeck safe methods', () => {
 
     await expect(vm.signal('ui.opened')).rejects.toBe(signalError);
     await expect(vm.queue('button.clicked')).rejects.toBe(queueError);
+    await expect(vm.flush()).rejects.toBe(flushError);
   });
 });

--- a/src/tests/plugin.test.ts
+++ b/src/tests/plugin.test.ts
@@ -1,12 +1,12 @@
-import { mount } from '@vue/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { defineComponent } from 'vue';
-import { useTelemetryDeck } from '../hooks';
-import { plugin } from '../plugin';
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent } from "vue";
+import { useTelemetryDeck } from "../hooks";
+import { plugin } from "../plugin";
 
 const { mockTelemetryDeck, telemetryDeckCtor } = vi.hoisted(() => {
   const instance = {
-    clientUser: 'test-user',
+    clientUser: "test-user",
     signal: vi.fn(),
     queue: vi.fn(),
     flush: vi.fn(),
@@ -20,19 +20,19 @@ const { mockTelemetryDeck, telemetryDeckCtor } = vi.hoisted(() => {
   };
 });
 
-vi.mock('@telemetrydeck/sdk', () => ({
+vi.mock("@telemetrydeck/sdk", () => ({
   default: telemetryDeckCtor,
 }));
 
 const HookConsumer = defineComponent({
-  name: 'HookConsumer',
+  name: "HookConsumer",
   setup() {
     return useTelemetryDeck();
   },
-  template: '<div />',
+  template: "<div />",
 });
 
-describe('plugin onError integration', () => {
+describe("plugin onError integration", () => {
   beforeEach(() => {
     telemetryDeckCtor.mockClear();
     mockTelemetryDeck.signal.mockReset();
@@ -40,10 +40,10 @@ describe('plugin onError integration', () => {
     mockTelemetryDeck.flush.mockReset();
   });
 
-  it('routes safe method errors to plugin onError handler', async () => {
-    const signalError = new Error('signal failed');
-    const queueError = new Error('queue failed');
-    const flushError = new Error('flush failed');
+  it("routes safe method errors to plugin onError handler", async () => {
+    const signalError = new Error("signal failed");
+    const queueError = new Error("queue failed");
+    const flushError = new Error("flush failed");
     const onError = vi.fn();
 
     mockTelemetryDeck.signal.mockRejectedValueOnce(signalError);
@@ -52,35 +52,35 @@ describe('plugin onError integration', () => {
 
     const wrapper = mount(HookConsumer, {
       global: {
-        plugins: [[plugin, { appID: 'test-app-id', onError }]],
+        plugins: [[plugin, { appID: "test-app-id", onError }]],
       },
     });
     const vm = wrapper.vm as unknown as ReturnType<typeof useTelemetryDeck>;
 
-    await expect(vm.safeSignal('ui.opened')).resolves.toBeUndefined();
-    await expect(vm.safeQueue('button.clicked')).resolves.toBeUndefined();
+    await expect(vm.safeSignal("ui.opened")).resolves.toBeUndefined();
+    await expect(vm.safeQueue("button.clicked")).resolves.toBeUndefined();
     await expect(vm.safeFlush()).resolves.toBeUndefined();
 
     expect(telemetryDeckCtor).toHaveBeenCalledWith({
-      appID: 'test-app-id',
-      clientUser: 'guest',
+      appID: "test-app-id",
+      clientUser: "guest",
       testMode: false,
     });
     expect(onError).toHaveBeenCalledTimes(3);
     expect(onError).toHaveBeenNthCalledWith(1, signalError, {
-      method: 'signal',
-      type: 'ui.opened',
+      method: "signal",
+      type: "ui.opened",
       payload: undefined,
       options: undefined,
     });
     expect(onError).toHaveBeenNthCalledWith(2, queueError, {
-      method: 'queue',
-      type: 'button.clicked',
+      method: "queue",
+      type: "button.clicked",
       payload: undefined,
       options: undefined,
     });
     expect(onError).toHaveBeenNthCalledWith(3, flushError, {
-      method: 'flush',
+      method: "flush",
     });
   });
 });

--- a/src/tests/plugin.test.ts
+++ b/src/tests/plugin.test.ts
@@ -9,6 +9,7 @@ const { mockTelemetryDeck, telemetryDeckCtor } = vi.hoisted(() => {
     clientUser: 'test-user',
     signal: vi.fn(),
     queue: vi.fn(),
+    flush: vi.fn(),
   };
 
   return {
@@ -36,15 +37,18 @@ describe('plugin onError integration', () => {
     telemetryDeckCtor.mockClear();
     mockTelemetryDeck.signal.mockReset();
     mockTelemetryDeck.queue.mockReset();
+    mockTelemetryDeck.flush.mockReset();
   });
 
   it('routes safe method errors to plugin onError handler', async () => {
     const signalError = new Error('signal failed');
     const queueError = new Error('queue failed');
+    const flushError = new Error('flush failed');
     const onError = vi.fn();
 
     mockTelemetryDeck.signal.mockRejectedValueOnce(signalError);
     mockTelemetryDeck.queue.mockRejectedValueOnce(queueError);
+    mockTelemetryDeck.flush.mockRejectedValueOnce(flushError);
 
     const wrapper = mount(HookConsumer, {
       global: {
@@ -55,13 +59,14 @@ describe('plugin onError integration', () => {
 
     await expect(vm.safeSignal('ui.opened')).resolves.toBeUndefined();
     await expect(vm.safeQueue('button.clicked')).resolves.toBeUndefined();
+    await expect(vm.safeFlush()).resolves.toBeUndefined();
 
     expect(telemetryDeckCtor).toHaveBeenCalledWith({
       appID: 'test-app-id',
       clientUser: 'guest',
       testMode: false,
     });
-    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledTimes(3);
     expect(onError).toHaveBeenNthCalledWith(1, signalError, {
       method: 'signal',
       type: 'ui.opened',
@@ -73,6 +78,9 @@ describe('plugin onError integration', () => {
       type: 'button.clicked',
       payload: undefined,
       options: undefined,
+    });
+    expect(onError).toHaveBeenNthCalledWith(3, flushError, {
+      method: 'flush',
     });
   });
 });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,4 +7,3 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
-    

--- a/tests/exports/import.mjs
+++ b/tests/exports/import.mjs
@@ -1,6 +1,8 @@
-import assert from 'node:assert/strict';
-import TelemetryDeckPlugin, { useTelemetryDeck } from '@peerigon/telemetrydeck-vue';
+import assert from "node:assert/strict";
+import TelemetryDeckPlugin, {
+  useTelemetryDeck,
+} from "@peerigon/telemetrydeck-vue";
 
-assert.equal(typeof TelemetryDeckPlugin, 'object');
-assert.equal(typeof TelemetryDeckPlugin.install, 'function');
-assert.equal(typeof useTelemetryDeck, 'function');
+assert.equal(typeof TelemetryDeckPlugin, "object");
+assert.equal(typeof TelemetryDeckPlugin.install, "function");
+assert.equal(typeof useTelemetryDeck, "function");

--- a/tests/exports/require.cjs
+++ b/tests/exports/require.cjs
@@ -1,6 +1,6 @@
-const assert = require('node:assert/strict');
-const TelemetryDeckVue = require('@peerigon/telemetrydeck-vue');
+const assert = require("node:assert/strict");
+const TelemetryDeckVue = require("@peerigon/telemetrydeck-vue");
 
-assert.equal(typeof TelemetryDeckVue.default, 'object');
-assert.equal(typeof TelemetryDeckVue.default.install, 'function');
-assert.equal(typeof TelemetryDeckVue.useTelemetryDeck, 'function');
+assert.equal(typeof TelemetryDeckVue.default, "object");
+assert.equal(typeof TelemetryDeckVue.default.install, "function");
+assert.equal(typeof TelemetryDeckVue.useTelemetryDeck, "function");

--- a/tests/pack/contents.mjs
+++ b/tests/pack/contents.mjs
@@ -1,0 +1,37 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const cacheDir = mkdtempSync(join(tmpdir(), "telemetrydeck-vue-npm-cache-"));
+let output;
+
+try {
+  output = execFileSync(
+    "npm",
+    ["pack", "--dry-run", "--ignore-scripts", "--json", "--cache", cacheDir],
+    { encoding: "utf8" },
+  );
+} finally {
+  rmSync(cacheDir, { recursive: true, force: true });
+}
+
+const [packResult] = JSON.parse(output);
+const packedFiles = new Set(packResult.files.map((file) => file.path));
+const requiredFiles = [
+  "dist/index.mjs",
+  "dist/index.cjs",
+  "dist/types/index.d.ts",
+];
+const missingFiles = requiredFiles.filter((file) => !packedFiles.has(file));
+
+if (missingFiles.length > 0) {
+  console.error(
+    `Missing required files from package tarball: ${missingFiles.join(", ")}`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Package tarball includes required files: ${requiredFiles.join(", ")}`,
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
+import vue from "@vitejs/plugin-vue";
+import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
-})
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,13 @@
-import { defineConfig } from 'vitest/config';
-import vue from '@vitejs/plugin-vue';
+import vue from "@vitejs/plugin-vue";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [vue()],
   test: {
     globals: true,
-    environment: 'jsdom',
+    environment: "jsdom",
     coverage: {
-      reporter: ['json-summary', 'text', 'lcov'],
+      reporter: ["json-summary", "text", "lcov"],
     },
   },
 });


### PR DESCRIPTION
## Summary

- Expose `flush` and `safeFlush` from `useTelemetryDeck()`
- add getQueueCount - to return number of events in the queue
- Add tests for raw `flush`, `safeFlush`, and plugin-level `onError` handling

- Update the local demo page with clearer controls for signal, queue, flush, safe methods, client user changes, and visible action/result/error state
- Add to demo page `onError` to test safe command onError callback

Other updates
- update README
- Add Prettier and checks
